### PR TITLE
update csi-resizer version to support volume capabilities

### DIFF
--- a/src/test/csi-neonsan/README.md
+++ b/src/test/csi-neonsan/README.md
@@ -57,7 +57,7 @@ Parameter | Description | Default
 `attacher.repository` | Image of csi-attacher | `csiplugin/k8scsi/csi-attacher`
 `attacher.tag` | Tag of csi-attacher | `v2.1.1`
 `resizer.repository` | Image of csi-resizer | `csiplugin/k8scsi/csi-resizer`
-`resizere.tag` | Tag of csi-resizer | `v0.4.0`
+`resizere.tag` | Tag of csi-resizer | `v0.5.1`
 `snapshotter.repository` | Image of csi-snapshotter | `csiplugin/csi-snapshotter`
 `snapshotter.tag` | Tag of csi-snapshotter | `v2.0.1`
 `registar.repository` | Image of csi-node-driver-registrar| `csiplugin/csi-node-driver-registrar`

--- a/src/test/csi-neonsan/values.yaml
+++ b/src/test/csi-neonsan/values.yaml
@@ -32,7 +32,7 @@ attacher:
   tag: v2.1.1
 resizer:
   repository: csiplugin/csi-resizer
-  tag: v0.4.0
+  tag: v0.5.1
 snapshotter:
   repository: csiplugin/csi-snapshotter
   tag: v2.0.1


### PR DESCRIPTION
Signed-off-by: stoneshi-yunify <stoneshi@yunify.com>

With this fix, the field `VolumeCapability` in `ControllerExpandVolumeRequest` of call `ControllerExpandVolume` will not be empty(it will be filled by the csi-resizer), therefore our code can check it's a block volume or filesystem volume. See more details on https://github.com/kubernetes-csi/external-resizer/pull/70