### PR TITLE
Add Litmus 2.0 Beta to main

### DIFF
--- a/src/main/litmus-2-0-0-beta/.helmignore
+++ b/src/main/litmus-2-0-0-beta/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/main/litmus-2-0-0-beta/Chart.yaml
+++ b/src/main/litmus-2-0-0-beta/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+appVersion: "2.0.0"
+description: A Helm chart to install litmus portal
+name: litmus-2-0-0-beta
+version: 2.0.22-Beta8
+kubeVersion: ">=1.16.0-0"
+home: https://litmuschaos.io
+sources:
+  - https://github.com/litmuschaos/litmus
+keywords:
+  - chaos-engineering
+  - resiliency
+  - kubernetes
+maintainers:
+  - name: rajdas98
+    email: raj.das@mayadata.io
+  - name: ispeakc0de
+    email: shubham.chaudhary@mayadata.io
+  - name: jasstkn
+    email: jasssstkn@yahoo.com
+icon: https://raw.githubusercontent.com/litmuschaos/icons/master/litmus.png

--- a/src/main/litmus-2-0-0-beta/README.md
+++ b/src/main/litmus-2-0-0-beta/README.md
@@ -1,0 +1,111 @@
+# litmus-2-0-0-beta
+
+![Version: 2.0.22-Beta8](https://img.shields.io/badge/Version-2.0.22--Beta8-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+
+A Helm chart to install litmus portal
+
+**Homepage:** <https://litmuschaos.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| rajdas98 | raj.das@mayadata.io |  |
+| ispeakc0de | shubham.chaudhary@mayadata.io |  |
+| jasstkn | jasssstkn@yahoo.com |  |
+
+## Source Code
+
+* <https://github.com/litmuschaos/litmus>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Installing the Chart
+
+To install this chart with the release name `litmus-portal`:
+
+```console
+$ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
+$ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
+```
+
+***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| adminConfig.DBPASSWORD | string | `"1234"` |  |
+| adminConfig.DBUSER | string | `"admin"` |  |
+| adminConfig.DB_PORT | string | `"27017"` |  |
+| adminConfig.DB_SERVER | string | `""` | leave empty if uses Mongo DB deployed by this chart |
+| adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
+| customLabels | object | `{}` | Additional labels |
+| image.imagePullSecrets | list | `[]` |  |
+| image.imageRegistryName | string | `"litmuschaos"` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `""` |  |
+| ingress.name | string | `"litmus-ingress"` |  |
+| ingress.tls | list | `[]` |  |
+| mongo.containerPort | int | `27017` |  |
+| mongo.image.pullPolicy | string | `"Always"` |  |
+| mongo.image.repository | string | `"mongo"` |  |
+| mongo.image.tag | string | `"4.2.8"` |  |
+| mongo.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| mongo.persistence.size | string | `"20Gi"` |  |
+| mongo.replicas | int | `1` |  |
+| mongo.resources | object | `{}` |  |
+| mongo.service.port | int | `27017` |  |
+| mongo.service.targetPort | int | `27017` |  |
+| mongo.service.type | string | `"ClusterIP"` |  |
+| openshift.route.annotations | object | `{}` |  |
+| openshift.route.enabled | bool | `false` |  |
+| openshift.route.host | string | `""` |  |
+| openshift.route.name | string | `"litmus-portal"` |  |
+| portal.frontend.containerPort | int | `8080` |  |
+| portal.frontend.image.pullPolicy | string | `"Always"` |  |
+| portal.frontend.image.repository | string | `"litmusportal-frontend"` |  |
+| portal.frontend.image.tag | string | `"2.0.0-Beta8"` |  |
+| portal.frontend.replicas | int | `1` |  |
+| portal.frontend.resources | object | `{}` |  |
+| portal.frontend.service.port | int | `9091` |  |
+| portal.frontend.service.targetPort | int | `8080` |  |
+| portal.frontend.service.type | string | `"NodePort"` |  |
+| portal.server.authServer.containerPort | int | `3000` |  |
+| portal.server.authServer.env.ADMIN_PASSWORD | string | `"litmus"` |  |
+| portal.server.authServer.env.ADMIN_USERNAME | string | `"admin"` |  |
+| portal.server.authServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.authServer.image.repository | string | `"litmusportal-auth-server"` |  |
+| portal.server.authServer.image.tag | string | `"2.0.0-Beta8"` |  |
+| portal.server.authServer.resources | object | `{}` |  |
+| portal.server.graphqlServer.containerPort | int | `8080` |  |
+| portal.server.graphqlServer.genericEnv.CONTAINER_RUNTIME_EXECUTOR | string | `"k8sapi"` |  |
+| portal.server.graphqlServer.genericEnv.HUB_BRANCH_NAME | string | `"v1.13.x"` |  |
+| portal.server.graphqlServer.genericEnv.PORTAL_ENDPOINT | string | `"http://litmusportal-server-service:9002"` |  |
+| portal.server.graphqlServer.genericEnv.SELF_CLUSTER | string | `"true"` |  |
+| portal.server.graphqlServer.genericEnv.SERVER_SERVICE_NAME | string | `"litmusportal-server-service"` |  |
+| portal.server.graphqlServer.image.pullPolicy | string | `"Always"` |  |
+| portal.server.graphqlServer.image.repository | string | `"litmusportal-server"` |  |
+| portal.server.graphqlServer.image.tag | string | `"2.0.0-Beta8"` |  |
+| portal.server.graphqlServer.imageEnv.ARGO_WORKFLOW_CONTROLLER_IMAGE | string | `"workflow-controller:v2.9.3"` |  |
+| portal.server.graphqlServer.imageEnv.ARGO_WORKFLOW_EXECUTOR_IMAGE | string | `"argoexec:v2.9.3"` |  |
+| portal.server.graphqlServer.imageEnv.EVENT_TRACKER_IMAGE | string | `"litmusportal-event-tracker:2.0.0-Beta8"` |  |
+| portal.server.graphqlServer.imageEnv.LITMUS_CHAOS_EXPORTER_IMAGE | string | `"chaos-exporter:1.13.5"` |  |
+| portal.server.graphqlServer.imageEnv.LITMUS_CHAOS_OPERATOR_IMAGE | string | `"chaos-operator:1.13.5"` |  |
+| portal.server.graphqlServer.imageEnv.LITMUS_CHAOS_RUNNER_IMAGE | string | `"chaos-runner:1.13.5"` |  |
+| portal.server.graphqlServer.imageEnv.SUBSCRIBER_IMAGE | string | `"litmusportal-subscriber:2.0.0-Beta8"` |  |
+| portal.server.graphqlServer.resources | object | `{}` |  |
+| portal.server.replicas | int | `1` |  |
+| portal.server.service.authServer.port | int | `9003` |  |
+| portal.server.service.authServer.targetPort | int | `3000` |  |
+| portal.server.service.graphqlServer.port | int | `9002` |  |
+| portal.server.service.graphqlServer.targetPort | int | `8080` |  |
+| portal.server.service.type | string | `"NodePort"` |  |
+| portal.server.serviceAccountName | string | `"litmus-server-account"` |  |
+| portalScope | string | `"cluster"` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/src/main/litmus-2-0-0-beta/README.md.gotmpl
+++ b/src/main/litmus-2-0-0-beta/README.md.gotmpl
@@ -1,0 +1,28 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+To install this chart with the release name `litmus-portal`:
+
+```console
+$ helm repo add litmuschaos https://litmuschaos.github.io/litmus-helm/
+$ helm install litmus-portal litmuschaos/litmus-2-0-0-beta
+```
+
+***Note***: This chart is in its beta release. To find it using `helm search` add `--devel` option.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/src/main/litmus-2-0-0-beta/templates/NOTES.txt
+++ b/src/main/litmus-2-0-0-beta/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Thank you for installing {{ .Chart.Name }} 😀
+
+Your release is named {{ .Release.Name }} and it's installed to namespace: {{ .Release.Namespace }}.
+
+Visit https://litmusdocs-beta.netlify.app/docs/introduction to find more info.

--- a/src/main/litmus-2-0-0-beta/templates/_helpers.tpl
+++ b/src/main/litmus-2-0-0-beta/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "litmus-portal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "litmus-portal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "litmus-portal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Specify default labels
+*/}}
+{{- define "litmus-portal.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "litmus-portal.name" . }}
+app.kubernetes.io/part-of: {{ template "litmus-portal.name" . }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ include "litmus-portal.chart" . }}
+litmuschaos.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Specify default selectors
+*/}}
+{{- define "litmus-portal.selectors" -}}
+app.kubernetes.io/name: {{ include "litmus-portal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/src/main/litmus-2-0-0-beta/templates/admin-config.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/admin-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-admin-config
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-admin-config
+data:
+  AgentScope: "{{ .Values.portalScope }}"
+  AgentNamespace: "{{ .Release.Namespace }}"
+  {{- if .Values.adminConfig.DB_SERVER }}
+  DB_SERVER: "mongodb://{{ .Values.adminConfig.DB_SERVER }}:{{ .Values.adminConfig.DB_PORT }}"
+  {{- else }}
+  DB_SERVER: "mongodb://{{ include "litmus-portal.fullname" . }}-mongo:{{ .Values.adminConfig.DB_PORT }}"
+  {{- end }}
+  JWTSecret: "{{ .Values.adminConfig.JWTSecret }}"
+  DB_USER: "{{ .Values.adminConfig.DBUSER }}"
+  DB_PASSWORD: "{{ .Values.adminConfig.DBPASSWORD }}"

--- a/src/main/litmus-2-0-0-beta/templates/frontend-deployment.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/frontend-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-frontend
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.portal.frontend.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
+        {{- include "litmus-portal.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+        - name: litmusportal-frontend
+          image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.frontend.image.repository }}:{{ .Values.portal.frontend.image.tag }}
+          imagePullPolicy: {{ .Values.portal.frontend.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.portal.frontend.resources | nindent 12 }}
+          ports:
+            - containerPort: {{ .Values.portal.frontend.containerPort }}
+              name: http
+          env:
+            - name: AGENT_SCOPE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: AgentScope

--- a/src/main/litmus-2-0-0-beta/templates/frontend-route.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/frontend-route.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.openshift.route.enabled -}}
+{{ $fullName := include "litmus-portal.fullname" . }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-route
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ $fullName }}-server
+    app.kubernetes.io/part-of: {{ $fullName }}-frontend
+  {{- with .Values.openshift.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host }}
+  {{- end }}
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: litmusportal-frontend-service
+{{- end }}

--- a/src/main/litmus-2-0-0-beta/templates/frontend-svc.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/frontend-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litmusportal-frontend-service
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.enabled }}
+  type: ClusterIP
+  {{- else }}
+  type: {{ .Values.portal.frontend.service.type }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.portal.frontend.service.port }}
+      targetPort: {{ .Values.portal.frontend.service.targetPort }}
+  selector:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend

--- a/src/main/litmus-2-0-0-beta/templates/ingress.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/ingress.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.ingress.enabled -}}
+{{ $fullName := include "litmus-portal.fullname" . }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-frontend
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range.Values.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.ingress.host }}
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+  {{- else }}
+  - http: 
+  {{- end }}
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      paths:
+      - path: /(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: litmusportal-frontend-service
+            port:
+              number: 9091
+      - path: /backend/(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: litmusportal-server-service
+            port:
+              number: 9002
+    {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      paths:
+      - path: /(.*)
+        backend:
+          serviceName: litmusportal-frontend-service
+          servicePort: 9091
+      - path: /backend/(.*)
+        backend:
+          serviceName: litmusportal-server-service
+          servicePort: 9002
+    {{- end }}
+  {{- end }}
+
+

--- a/src/main/litmus-2-0-0-beta/templates/mongo-sts.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/mongo-sts.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-mongo
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mongo
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database
+  serviceName: mongo
+  replicas: {{ .Values.mongo.replicas }}
+  template:
+    metadata:
+      labels:
+        app: mongo
+        app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database
+        {{- include "litmus-portal.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+        - name: mongo
+          image: {{ .Values.image.imageRegistryName }}/{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}
+          ports:
+            - containerPort: {{ .Values.mongo.containerPort }}
+              name: http
+          imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_USER
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_PASSWORD
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-persistent-storage
+      spec:
+        {{- if .Values.mongo.persistence.storageClass }}
+        storageClassName: {{ .Values.mongo.persistence.storageClass }}
+        {{- end }}
+        accessModes:
+          - {{ .Values.mongo.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.mongo.persistence.size }}

--- a/src/main/litmus-2-0-0-beta/templates/mongo-svc.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/mongo-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-mongo
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app: mongo
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mongo.service.type }}
+  ports:
+    - port: {{ .Values.mongo.service.port }}
+      targetPort: {{ .Values.mongo.service.targetPort }}
+  selector:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-database

--- a/src/main/litmus-2-0-0-beta/templates/server-cluster-role-binding.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+{{ if eq .Values.portalScope "cluster" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-server-rb
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.portal.server.serviceAccountName }}
+    namespace:  {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "litmus-portal.fullname" . }}-server
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/src/main/litmus-2-0-0-beta/templates/server-cluster-role.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-cluster-role.yaml
@@ -1,0 +1,16 @@
+{{ if eq .Values.portalScope "cluster" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-server
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+{{ end }}

--- a/src/main/litmus-2-0-0-beta/templates/server-deployment.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.portal.server.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+        {{- include "litmus-portal.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.portal.server.serviceAccountName }}
+      {{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+        - name: graphql-server
+          image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.graphqlServer.image.repository }}:{{ .Values.portal.server.graphqlServer.image.tag }}
+          imagePullPolicy: {{ .Values.portal.server.graphqlServer.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.portal.server.graphqlServer.containerPort }}
+              name: graphql-srver
+          resources:
+            {{- toYaml .Values.portal.server.graphqlServer.resources | nindent 12 }}
+          env:
+            - name: DB_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_SERVER
+            - name: JWT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: JWTSecret
+            - name: LITMUS_PORTAL_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PORTAL_SCOPE
+              value: {{ .Values.portalScope }}
+            {{- if eq .Values.portalScope "namespace" }}
+            - name: PORTAL_ENDPOINT
+              value: "http://{{ .Values.portal.server.graphqlServer.genericEnv.SERVER_SERVICE_NAME }}:{{ .Values.portal.server.service.graphqlServer.port }}"
+            {{- end }}
+            - name: AGENT_SCOPE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: AgentScope
+            - name: AGENT_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: AgentNamespace
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_USER
+            - name: DB_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_PASSWORD
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- $imageRegistry := .Values.image.imageRegistryName -}}
+            {{- range $key, $val := .Values.portal.server.graphqlServer.imageEnv }}
+            - name: {{ $key }}
+              value: {{ $imageRegistry }}/{{ $val }}
+            {{- end }}
+            {{- range $key, $val := .Values.portal.server.graphqlServer.genericEnv }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            - name: INGRESS
+              value: "{{ .Values.ingress.enabled }}"
+            - name: INGRESS_NAME
+              value: "{{ .Values.ingress.name }}"
+        - name: auth-server
+          image: {{ .Values.image.imageRegistryName }}/{{ .Values.portal.server.authServer.image.repository }}:{{ .Values.portal.server.authServer.image.tag }}
+          imagePullPolicy: {{ .Values.portal.server.authServer.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.portal.server.authServer.containerPort }}
+              name: auth-server
+          env:
+            - name: DB_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_SERVER
+            - name: JWT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: JWTSecret
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_USER
+            - name: DB_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "litmus-portal.fullname" . }}-admin-config
+                  key: DB_PASSWORD
+            {{- range $key, $val := .Values.portal.server.authServer.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}

--- a/src/main/litmus-2-0-0-beta/templates/server-role.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-role.yaml
@@ -1,0 +1,17 @@
+{{ if eq .Values.portalScope "namespace" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-server
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+{{ end }}

--- a/src/main/litmus-2-0-0-beta/templates/server-rolebinding.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{ if eq .Values.portalScope "namespace" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "litmus-portal.fullname" . }}-server-rb
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.portal.server.serviceAccountName }}
+    namespace:  {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "litmus-portal.fullname" . }}-server
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/src/main/litmus-2-0-0-beta/templates/server-sa.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.portal.server.serviceAccountName }}
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}

--- a/src/main/litmus-2-0-0-beta/templates/server-svc.yaml
+++ b/src/main/litmus-2-0-0-beta/templates/server-svc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litmusportal-server-service
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server
+    {{- include "litmus-portal.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.enabled }}
+  type: ClusterIP
+  {{- else }}
+  type: {{ .Values.portal.server.service.type }}
+  {{- end }}
+  ports:
+    - name: graphql-server
+      port: {{ .Values.portal.server.service.graphqlServer.port }}
+      targetPort: {{ .Values.portal.server.service.graphqlServer.targetPort }}
+    - name: auth-server
+      port: {{ .Values.portal.server.service.authServer.port }}
+      targetPort: {{ .Values.portal.server.service.authServer.targetPort }}
+  selector:
+    app.kubernetes.io/component: {{ include "litmus-portal.name" . }}-server

--- a/src/main/litmus-2-0-0-beta/values.yaml
+++ b/src/main/litmus-2-0-0-beta/values.yaml
@@ -1,0 +1,158 @@
+# Default values for litmus.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+portalScope: cluster
+
+# -- Additional labels
+customLabels: {}
+
+adminConfig:
+  DBUSER: "admin"
+  DBPASSWORD: "1234"
+  JWTSecret: "litmus-portal@123"
+  # -- leave empty if uses Mongo DB deployed by this chart
+  DB_SERVER: ""
+  DB_PORT: "27017"
+
+image:
+  imageRegistryName: litmuschaos
+  # Optional pod imagePullSecrets
+  imagePullSecrets: []
+
+ingress:
+  enabled: false
+  name: litmus-ingress
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/rewrite-target: /$1
+
+  host: ""
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts: []
+
+portal:
+  frontend:
+    replicas: 1
+    image:
+      repository: litmusportal-frontend
+      tag: 2.0.0-Beta8
+      pullPolicy: "Always"
+    containerPort: 8080
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 400Mi
+    # requests:
+    #   cpu: 200m
+    #   memory: 400Mi
+    service:
+      type: NodePort
+      port: 9091
+      targetPort: 8080
+
+  server:
+    replicas: 1
+    serviceAccountName: litmus-server-account
+    graphqlServer:
+      image:
+        repository: litmusportal-server
+        tag: 2.0.0-Beta8
+        pullPolicy: "Always"
+      containerPort: 8080
+      imageEnv:
+        SUBSCRIBER_IMAGE: "litmusportal-subscriber:2.0.0-Beta8"
+        EVENT_TRACKER_IMAGE: "litmusportal-event-tracker:2.0.0-Beta8"
+        ARGO_WORKFLOW_CONTROLLER_IMAGE: "workflow-controller:v2.9.3"
+        ARGO_WORKFLOW_EXECUTOR_IMAGE: "argoexec:v2.9.3"
+        LITMUS_CHAOS_OPERATOR_IMAGE: "chaos-operator:1.13.5"
+        LITMUS_CHAOS_RUNNER_IMAGE: "chaos-runner:1.13.5"
+        LITMUS_CHAOS_EXPORTER_IMAGE: "chaos-exporter:1.13.5"
+      genericEnv:
+        SELF_CLUSTER: "true"
+        SERVER_SERVICE_NAME: "litmusportal-server-service"
+        PORTAL_ENDPOINT: "http://litmusportal-server-service:9002"
+        CONTAINER_RUNTIME_EXECUTOR: "k8sapi"
+        HUB_BRANCH_NAME: "v1.13.x"
+      resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 200m
+      #   memory: 400Mi
+      # requests:
+      #   cpu: 200m
+      #   memory: 400Mi
+    authServer:
+      image:
+        repository: litmusportal-auth-server
+        tag: 2.0.0-Beta8
+        pullPolicy: "Always"
+      containerPort: 3000
+      env:
+        ADMIN_USERNAME: "admin"
+        ADMIN_PASSWORD: "litmus"
+      resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 200m
+      #   memory: 250Mi
+      # requests:
+      #   cpu: 200m
+      #   memory: 250Mi
+    service:
+      type: NodePort
+      graphqlServer:
+        port: 9002
+        targetPort: 8080
+      authServer:
+        port: 9003
+        targetPort: 3000
+
+mongo:
+  replicas: 1
+  image:
+    repository: mongo
+    tag: 4.2.8
+    pullPolicy: "Always"
+  containerPort: 27017
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 200m
+  #   memory: 400Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 400Mi
+  resources: {}
+  persistence:
+    size: 20Gi
+    accessMode: ReadWriteOnce
+    # storageClass: ""
+  service:
+    type: ClusterIP
+    port: 27017
+    targetPort: 27017
+
+# OpenShift specific configuration
+openshift:
+  # If service should be exposed using an OpenShift route
+  route:
+    enabled: false
+    name: litmus-portal
+    annotations: {}
+    host: ""


### PR DESCRIPTION
Signed-off-by: Sayan Mondal <sayan@chaosnative.com>

## App Introduction:

Litmus is a toolset to do cloud-native chaos engineering. Litmus provides tools to orchestrate chaos on Kubernetes to help SREs find weaknesses in their deployments. Litmus can be used to run chaos experiments initially in the staging environment and eventually in production to find bugs, vulnerabilities, fixing which leads to increased resilience of the system.

## Screenshots:

![Landing](https://user-images.githubusercontent.com/34975209/124415489-96be5b80-dd72-11eb-8031-29acd3d587d4.png)
![Tune](https://user-images.githubusercontent.com/34975209/124415542-b5bced80-dd72-11eb-8427-8aef9ba7d910.png)
![PodtatoLogs](https://user-images.githubusercontent.com/34975209/124415549-bce3fb80-dd72-11eb-9f3f-05d0afb1269c.png)
![Workflows  Main Page](https://user-images.githubusercontent.com/34975209/124415572-c705fa00-dd72-11eb-89b3-72ff9efc8d24.png)
![Team Settings (Members Page)](https://user-images.githubusercontent.com/34975209/124415610-da18ca00-dd72-11eb-8019-9b18d959fc68.png)
![Workflows  Main Page (1)](https://user-images.githubusercontent.com/34975209/124415626-de44e780-dd72-11eb-84d0-19ad33e4a098.png)
