### PR TITLE
Add resources limits and requests for csi-qingcloud

### DIFF
--- a/src/test/csi-qingcloud/Chart.yaml
+++ b/src/test/csi-qingcloud/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.2.1
 name: csi-qingcloud
 description: A Helm chart for Qingcloud CSI Driver
-version: 1.2.7
+version: 1.2.8
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/yunify/qingcloud-csi
 sources:
@@ -25,8 +25,8 @@ keywords:
   - qingcloud
   - csi
 maintainers:
-  - name: Min Zhang
-    email: arminzhang@yunify.com
+  - name: Yonghong Shi
+    email: stoneshi@yunify.com
   - name: Zhengyi Lai
     email: zheng1@yunify.com
 icon: https://s3.qingcloud.com/static/assets/images/icons/common/nav_logo_white.svg?v=1510299508

--- a/src/test/csi-qingcloud/OWNERS
+++ b/src/test/csi-qingcloud/OWNERS
@@ -1,6 +1,6 @@
 approvers:
 - zheng1
-- min-zh
+- stoneshi-yunify
 reviewers:
 - zheng1
-- min-zh
+- stoneshi-yunify

--- a/src/test/csi-qingcloud/README.md
+++ b/src/test/csi-qingcloud/README.md
@@ -30,7 +30,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the redis chart and their default values.
+The following table lists the configurable parameters of the chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---

--- a/src/test/csi-qingcloud/templates/controller-deploy.yaml
+++ b/src/test/csi-qingcloud/templates/controller-deploy.yaml
@@ -44,11 +44,11 @@ spec:
         image: "{{ .Values.provisioner.repository }}:{{ .Values.provisioner.tag }}"
         resources:
           limits:
-            memory: "80Mi"
-            cpu: "80m"
+            memory: "{{ .Values.provisioner.resources.limits.memory }}"
+            cpu: "{{ .Values.provisioner.resources.limits.cpu }}"
           requests:
-            memory: "80Mi"
-            cpu: "80m"
+            memory: "{{ .Values.provisioner.resources.requests.memory }}"
+            cpu: "{{ .Values.provisioner.resources.requests.cpu }}"
         args:
         - "--csi-address=$(ADDRESS)"
         - "--enable-leader-election"
@@ -71,11 +71,11 @@ spec:
         image: "{{ .Values.attacher.repository }}:{{ .Values.attacher.tag }}"
         resources:
           limits:
-            memory: "80Mi"
-            cpu: "80m"
+            memory: "{{ .Values.attacher.resources.limits.memory }}"
+            cpu: "{{ .Values.attacher.resources.limits.cpu }}"
           requests:
-            memory: "80Mi"
-            cpu: "80m"
+            memory: "{{ .Values.attacher.resources.requests.memory }}"
+            cpu: "{{ .Values.attacher.resources.requests.cpu }}"
         args:
         - "--csi-address=$(ADDRESS)"
         - "--leader-election"
@@ -100,11 +100,11 @@ spec:
         image: "{{ .Values.snapshotter.repository }}:{{ .Values.snapshotter.tag }}"
         resources:
           limits:
-            memory: "20Mi"
-            cpu: "20m"
+            memory: "{{ .Values.snapshotter.resources.limits.memory }}"
+            cpu: "{{ .Values.snapshotter.resources.limits.cpu }}"
           requests:
-            memory: "20Mi"
-            cpu: "20m"
+            memory: "{{ .Values.snapshotter.resources.requests.memory }}"
+            cpu: "{{ .Values.snapshotter.resources.requests.cpu }}"
         args:
           - "--csi-address=$(ADDRESS)"
           - "--leader-election=false"
@@ -122,11 +122,11 @@ spec:
         image: "{{ .Values.resizer.repository }}:{{ .Values.resizer.tag }}"
         resources:
           limits:
-            memory: "20Mi"
-            cpu: "20m"
+            memory: "{{ .Values.resizer.resources.limits.memory }}"
+            cpu: "{{ .Values.resizer.resources.limits.cpu }}"
           requests:
-            memory: "20Mi"
-            cpu: "20m"
+            memory: "{{ .Values.resizer.resources.requests.memory }}"
+            cpu: "{{ .Values.resizer.resources.requests.cpu }}"
         args:
           - "--csi-address=$(ADDRESS)"
           - "--leader-election"
@@ -143,11 +143,11 @@ spec:
         image: "{{ .Values.driver.repository }}:{{ include "driver.version" . }}"
         resources:
           limits:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: "{{ .Values.controller.resources.limits.memory }}"
+            cpu: "{{ .Values.controller.resources.limits.cpu }}"
           requests:
-            memory: "50Mi"
-            cpu: "50m"
+            memory: "{{ .Values.controller.resources.requests.memory }}"
+            cpu: "{{ .Values.controller.resources.requests.cpu }}"
         args :
           - "--config=/etc/config/config.yaml"
           - "--drivername={{ .Values.driver.name }}"

--- a/src/test/csi-qingcloud/templates/node-ds.yaml
+++ b/src/test/csi-qingcloud/templates/node-ds.yaml
@@ -54,11 +54,11 @@ spec:
           image: "{{ .Values.registrar.repository }}:{{ .Values.registrar.tag }}"
           resources:
             limits:
-              memory: "20Mi"
-              cpu: "10m"
+              memory: "{{ .Values.registrar.resources.limits.memory }}"
+              cpu: "{{ .Values.registrar.resources.limits.cpu }}"
             requests:
-              memory: "20Mi"
-              cpu: "10m"
+              memory: "{{ .Values.registrar.resources.requests.memory }}"
+              cpu: "{{ .Values.registrar.resources.requests.cpu }}"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ .Values.driver.name }}/csi.sock"
@@ -87,11 +87,11 @@ spec:
           image: "{{ .Values.driver.repository }}:{{ include "driver.version" . }}"
           resources:
             limits:
-              memory: "50Mi"
-              cpu: "50m"
+              memory: "{{ .Values.node.resources.limits.memory }}"
+              cpu: "{{ .Values.node.resources.limits.cpu }}"
             requests:
-              memory: "50Mi"
-              cpu: "50m"
+              memory: "{{ .Values.node.resources.requests.memory }}"
+              cpu: "{{ .Values.node.resources.requests.cpu }}"
           args :
             - "--config=/etc/config/config.yaml"
             - "--drivername={{ .Values.driver.name }}"

--- a/src/test/csi-qingcloud/values.yaml
+++ b/src/test/csi-qingcloud/values.yaml
@@ -32,22 +32,74 @@ driver:
   maxVolume: 10
   kubeletDir: /var/lib/kubelet
 
+controller:
+  resources:
+    limits:
+      memory: 50Mi
+      cpu: 100m
+    requests:
+      memory: 50Mi
+      cpu: 100m
 provisioner:
   repository: csiplugin/csi-provisioner
   tag: v1.5.0
   volumeNamePrefix: pvc
+  resources:
+    limits:
+      memory: 80Mi
+      cpu: 80m
+    requests:
+      memory: 80Mi
+      cpu: 80m
 attacher:
   repository: csiplugin/csi-attacher
   tag: v2.1.1
+  resources:
+    limits:
+      memory: 80Mi
+      cpu: 80m
+    requests:
+      memory: 80Mi
+      cpu: 80m
 resizer:
   repository: csiplugin/csi-resizer
   tag: v0.4.0
+  resources:
+    limits:
+      memory: 20Mi
+      cpu: 20m
+    requests:
+      memory: 20Mi
+      cpu: 20m
 snapshotter:
   repository: csiplugin/csi-snapshotter
   tag: v2.0.1
+  resources:
+    limits:
+      memory: 20Mi
+      cpu: 20m
+    requests:
+      memory: 20Mi
+      cpu: 20m
+
 registrar:
   repository: csiplugin/csi-node-driver-registrar
   tag: v1.2.0
+  resources:
+    limits:
+      memory: 20Mi
+      cpu: 10m
+    requests:
+      memory: 20Mi
+      cpu: 10m
+node:
+  resources:
+    limits:
+      memory: 50Mi
+      cpu: 100m
+    requests:
+      memory: 50Mi
+      cpu: 100m
 
 sc:
   enable: true


### PR DESCRIPTION
change summary:
- expose all containers' resources settings, as asked by many users.
- enlarge controller and node's default cpu requests&limits, we've observed many out-of-cpu alerting in field.