### PR TITLE
update csi-driver apiVersion

### DIFF
--- a/src/test/csi-neonsan/Chart.yaml
+++ b/src/test/csi-neonsan/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.2.1
 name: csi-neonsan
 description: A Helm chart for NeonSAN CSI Driver
-version: 1.2.4
+version: 1.2.5
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/yunify/qingstor-csi
 sources:

--- a/src/test/csi-neonsan/templates/csi-driver.yaml
+++ b/src/test/csi-neonsan/templates/csi-driver.yaml
@@ -12,7 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-apiVersion: storage.k8s.io/v1beta1
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: storage.k8s.io/v1
+{{ else }}
+apiversion: storage.k8s.io/v1beta1
+{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driver.name }}

--- a/src/test/csi-qingcloud/Chart.yaml
+++ b/src/test/csi-qingcloud/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.2.1
 name: csi-qingcloud
 description: A Helm chart for Qingcloud CSI Driver
-version: 1.2.11
+version: 1.2.12
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/yunify/qingcloud-csi
 sources:

--- a/src/test/csi-qingcloud/templates/qingcloud-driver.yaml
+++ b/src/test/csi-qingcloud/templates/qingcloud-driver.yaml
@@ -12,7 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-apiVersion: storage.k8s.io/v1beta1
+{{ if semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: storage.k8s.io/v1
+{{ else }}
+apiversion: storage.k8s.io/v1beta1
+{{ end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.driver.name }}


### PR DESCRIPTION
This  v1beta1 version of the csiDriver is deprecated after K8s 1.22.
/cc @stoneshi-yunify @zheng1 
Signed-off-by: f10atin9 <f10atin9@kubesphere.io>