### PR TITLE
disable allowVolumeExpansion for nfs provisioner

### DIFF
--- a/src/main/nfs-client-provisioner/Chart.yaml
+++ b/src/main/nfs-client-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-client is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-client-provisioner
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
-version: 4.0.10
+version: 4.0.11
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
 maintainers:

--- a/src/main/nfs-client-provisioner/README.md
+++ b/src/main/nfs-client-provisioner/README.md
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `image.pullPolicy`                | Image pull policy                           | `IfNotPresent`                                            |
 | `storageClass.name`               | Name of the storageClass                    | `nfs-client`                                              |
 | `storageClass.defaultClass`       | Set as the default StorageClass             | `false`	                                              |
-| `storageClass.allowVolumeExpansion`       | Allow expanding the volume          | `true`	                                              |
+| `storageClass.allowVolumeExpansion`       | Allow expanding the volume          | `false`	                                              |
 | `storageClass.reclaimPolicy`    | Method used to reclaim an obsoleted volume                 | `Delete` 	                              |
 | `storageClass.provisionerName`    | Name of the provisionerName                 | null 	                                              |
 | `storageClass.archiveOnDelete`    | Archive pvc when deleting                   | `true` 	                                              |

--- a/src/main/nfs-client-provisioner/values.yaml
+++ b/src/main/nfs-client-provisioner/values.yaml
@@ -31,7 +31,7 @@ storageClass:
   name: nfs-client
 
   # Allow volume to be expanded dynamically
-  allowVolumeExpansion: true
+  allowVolumeExpansion: false
 
   # Method used to reclaim an obsoleted volume
   reclaimPolicy: Delete


### PR DESCRIPTION
Signed-off-by: stoneshi-yunify <stoneshi@kubesphere.io>

nfs provisioner does not support expanding volume, so we should disable the allowVolumeExpansion in sc by default.