### PR TITLE
Release qingcloud-csi helm 1.3.0

### DIFF
--- a/src/test/csi-qingcloud/Chart.yaml
+++ b/src/test/csi-qingcloud/Chart.yaml
@@ -13,10 +13,10 @@
 #  limitations under the License.
 apiVersion: v2
 
-appVersion: 1.2.2
+appVersion: 1.3.0
 name: csi-qingcloud
 description: A Helm chart for Qingcloud CSI Driver
-version: 1.2.14
+version: 1.3.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/yunify/qingcloud-csi
 sources:


### PR DESCRIPTION
Qingcloud-csi uses the new version of csi/spec, so Qingcloud-csi helm is released as 1.3.0.
For more details, please refer to Realease Note of Qingcloud-csi v1.3.0 .

Signed-off-by: f10atin9 <f10atin9@kubesphere.io>