### PR TITLE
add VPA yaml and CHANGELOG.

### DIFF
--- a/src/test/csi-qingcloud/CHANGELOG/CHANGELOG-1.3.md
+++ b/src/test/csi-qingcloud/CHANGELOG/CHANGELOG-1.3.md
@@ -1,6 +1,6 @@
 # Changelog since v1.3.0
-***
+
 ## v1.3.1
 New Features
-- Add vpa.yaml. User can turn on enableVPA in values.yaml to create VerticalPodAutoscaler for csi-qingcloud-controller. (#188)
+- Add vpa.yaml. User can turn on enableVPA in values.yaml to create VerticalPodAutoscaler for csi-qingcloud-controller. ([#188](https://github.com/kubesphere/helm-charts/pull/188))
 

--- a/src/test/csi-qingcloud/CHANGELOG/CHANGELOG-1.3.md
+++ b/src/test/csi-qingcloud/CHANGELOG/CHANGELOG-1.3.md
@@ -1,0 +1,6 @@
+# Changelog since v1.3.0
+***
+## v1.3.1
+New Features
+- Add vpa.yaml. User can turn on enableVPA in values.yaml to create VerticalPodAutoscaler for csi-qingcloud-controller. (#188)
+

--- a/src/test/csi-qingcloud/Chart.yaml
+++ b/src/test/csi-qingcloud/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 appVersion: 1.3.0
 name: csi-qingcloud
 description: A Helm chart for Qingcloud CSI Driver
-version: 1.3.0
+version: 1.3.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/yunify/qingcloud-csi
 sources:

--- a/src/test/csi-qingcloud/README.md
+++ b/src/test/csi-qingcloud/README.md
@@ -45,13 +45,13 @@ Vertical Pod Autoscaler (VPA) frees the users from necessity of setting up-to-da
 
 - Set `enableVPA` to `true` in ` values.yaml ` to apply VerticalPodAutoscaler for csi-qingcloud-controller. (Need to make sure that [vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) can work first.)
 
-- If you need to modify the `minAllowed` and `maxAllowed` of the container, modify the value of the container in `value.yaml` .
+- Specify the `minAllowed` and `maxAllowed` value for each container in `values.yaml`, if the defaults don't meet your need.
 
 - When setting limits VPA will conform to resource policies. It will maintain limit to request ratio specified for all containers. VPA will try to cap recommendations between min and max of limit ranges. If limit range conflicts and VPA resource policy conflict then VPA will follow **VPA policy** (and set values outside limit range).
   For details, refer to the following [examples](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#examples)
 
 
-- By default VPA won't update the resource requests/limits of the container if the replicas is 1, in this case, the csi-qingcloud-controller, you can enforce this by adding below arguments to the vpa-updater deployment:
+- By default, VPA won't update the resource requests/limits of the container if the replicas is 1, in this case, the csi-qingcloud-controller, you can enforce this by adding below arguments to the vpa-updater deployment:
 ```yaml
   args:
     - "--min-replicas=1"
@@ -63,9 +63,9 @@ The following table lists the configurable parameters of the chart and their def
 
 Parameter | Description | Default
 --- | --- | ---
-`config.qy_access_key_id` | Access key id of QingCloud | ``
-`config.qy_secret_access_key` | Access secret of QingCloud | ``
-`config.zone` | Zone of QingCloud | ``
+`config.qy_access_key_id` | Access key id of QingCloud | 
+`config.qy_secret_access_key` | Access secret of QingCloud | 
+`config.zone` | Zone of QingCloud | 
 `config.host` | API host of QingCloud | `api.qingcloud.com`
 `config.port` | API port of QingCloud | `443`
 `config.protocol` | API protocol of QingCloud | `https`
@@ -74,9 +74,9 @@ Parameter | Description | Default
 `config.connection_timeout` | Retry time out of API| `30`
 `driver.name` | Name of the CSI driver | `disk.csi.qingcloud.com`
 `driver.repository` | Image of CSI plugin| `csiplugin/csi-qingcloud`
-`driver.tag` | Tag of CSI plugin, defaults to chart appVersion | `""`
 `driver.pullPolicy` | Image pull policy of CSI plugin | `IfNotPresent`
-`driver.maxVolume` | Max volume of CSI plugin | `10`
+`driver.maxVolume` | Max volume of CSI plugin | `9`
+`driver.retryDetachTimesMax` | Max time of retry detach | `100`
 `driver.kubeletDir` | Directory of kubelet | `/var/lib/kubelet`
 `provisioner.repository` | Image of csi-provisioner | `csiplugin/csi-provisioner`
 `provisioner.tag` | Tag of csi-provisioner | `v2.2.2`
@@ -93,8 +93,10 @@ Parameter | Description | Default
 `sc.isDefaultClass` | Whether to set this StorageClass as the default StorageClass | `false`
 `sc.name` | Name of storage class | `csi-qingcloud`
 `sc.type` | [Type](https://github.com/yunify/qingcloud-csi/blob/master/docs/user-guide.md#type-maxsize-minsize-stepsize) parameter of storage class. If set`auto`, disk type will be automatically set according to instance type| `auto`
-`sc.tags` | [Tag](https://github.com/yunify/qingcloud-csi/blob/master/docs/user-guide.md#tags) parameter of storage class | ``
+`sc.replica` | `1` represents single duplication disk，`2` represents multiple duplication disk | 2
+`sc.tags` | [Tag](https://github.com/yunify/qingcloud-csi/blob/master/docs/user-guide.md#tags) parameter of storage class | 
 `sc.fsType` | [FsType](https://github.com/yunify/qingcloud-csi/blob/master/docs/user-guide.md#fstype) parameter of storage class | `ext4`
 `sc.reclaimPolicy` | ReclaimPolicy parameter of storage class | `Delete`
 `sc.allowVolumeExpansion` | AllowVolumeExpansion parameter of storage class | `true`
 `sc.volumeBindingMode` | [VolumeBindingMode](https://github.com/yunify/qingcloud-csi/blob/master/docs/user-guide.md#topology-awareness) parameter of storage class | `WaitForFirstConsumer`
+`enableVPA` | Whether to enable [vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) | `false`

--- a/src/test/csi-qingcloud/README.md
+++ b/src/test/csi-qingcloud/README.md
@@ -43,14 +43,15 @@ Chart Version | Snapshot CRDs Version | Min K8s Version
 ## Vertical Pod Autoscaler
 Vertical Pod Autoscaler (VPA) frees the users from necessity of setting up-to-date resource limits and requests for the containers in their pods.
 
-Set `enableVPA` to `true` in ` values.yaml ` to apply VerticalPodAutoscaler for csi-qingcloud-controller. (Need to make sure that [vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) has been installed first.)
+- Set `enableVPA` to `true` in ` values.yaml ` to apply VerticalPodAutoscaler for csi-qingcloud-controller. (Need to make sure that [vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) can work first.)
 
-If you need to modify the `minAllowed` and `maxAllowed` of the container, modify the value of the container in `value.yaml` .
+- If you need to modify the `minAllowed` and `maxAllowed` of the container, modify the value of the container in `value.yaml` .
 
-VPA will try to cap recommendations between min and max of limit ranges. If limit range conflicts and VPA resource policy conflict then VPA will follow **VPA policy** (and set values outside limit range).
-**VPA will keep the QoS class as guaranteed.**
+- When setting limits VPA will conform to resource policies. It will maintain limit to request ratio specified for all containers. VPA will try to cap recommendations between min and max of limit ranges. If limit range conflicts and VPA resource policy conflict then VPA will follow **VPA policy** (and set values outside limit range).
+  For details, refer to the following [examples](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#examples)
 
-If the replicas value is 1, Then in your updater deployment you will just have to add
+
+- By default VPA won't update the resource requests/limits of the container if the replicas is 1, in this case, the csi-qingcloud-controller, you can enforce this by adding below arguments to the vpa-updater deployment:
 ```yaml
   args:
     - "--min-replicas=1"

--- a/src/test/csi-qingcloud/README.md
+++ b/src/test/csi-qingcloud/README.md
@@ -40,6 +40,22 @@ Chart Version | Snapshot CRDs Version | Min K8s Version
  &lt;= 1.2.8 | only v1beta1 | 1.14 
  &gt;= 1.2.9 | both v1beta1 and v1, only v1 | 1.17 
 
+## Vertical Pod Autoscaler
+Vertical Pod Autoscaler (VPA) frees the users from necessity of setting up-to-date resource limits and requests for the containers in their pods.
+
+Set `enableVPA` to `true` in ` values.yaml ` to apply VerticalPodAutoscaler for csi-qingcloud-controller. (Need to make sure that [vertical-pod-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) has been installed first.)
+
+If you need to modify the `minAllowed` and `maxAllowed` of the container, modify the value of the container in `value.yaml` .
+
+VPA will try to cap recommendations between min and max of limit ranges. If limit range conflicts and VPA resource policy conflict then VPA will follow **VPA policy** (and set values outside limit range).
+**VPA will keep the QoS class as guaranteed.**
+
+If the replicas value is 1, Then in your updater deployment you will just have to add
+```yaml
+  args:
+    - "--min-replicas=1"
+```
+
 ## Configuration
 
 The following table lists the configurable parameters of the chart and their default values.

--- a/src/test/csi-qingcloud/templates/vpa.yaml
+++ b/src/test/csi-qingcloud/templates/vpa.yaml
@@ -1,0 +1,57 @@
+{{ if .Values.enableVPA }}
+---
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: csi-qingcloud-vpa
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: csi-qingcloud-controller
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: 'csi-qingcloud'
+        minAllowed:
+          cpu: "{{ .Values.controller.vpa.minAllowed.cpu }}"
+          memory: "{{ .Values.controller.vpa.minAllowed.memory }}"
+        maxAllowed:
+          cpu: "{{ .Values.controller.vpa.maxAllowed.cpu }}"
+          memory: "{{ .Values.controller.vpa.maxAllowed.memory }}"
+        controlledResources: ["cpu", "memory"]
+      - containerName: 'csi-provisioner'
+        minAllowed:
+          cpu: "{{ .Values.provisioner.vpa.minAllowed.cpu }}"
+          memory: "{{ .Values.provisioner.vpa.minAllowed.memory }}"
+        maxAllowed:
+          cpu: "{{ .Values.provisioner.vpa.maxAllowed.cpu }}"
+          memory: "{{ .Values.provisioner.vpa.maxAllowed.memory }}"
+        controlledResources: ["cpu", "memory"]
+      - containerName: 'csi-attacher'
+        minAllowed:
+          cpu: "{{ .Values.attacher.vpa.minAllowed.cpu }}"
+          memory: "{{ .Values.attacher.vpa.minAllowed.memory }}"
+        maxAllowed:
+          cpu: "{{ .Values.attacher.vpa.maxAllowed.cpu }}"
+          memory: "{{ .Values.attacher.vpa.maxAllowed.memory }}"
+        controlledResources: ["cpu", "memory"]
+      - containerName: 'csi-snapshotter'
+        minAllowed:
+          cpu: "{{ .Values.snapshotter.vpa.minAllowed.cpu }}"
+          memory: "{{ .Values.snapshotter.vpa.minAllowed.memory }}"
+        maxAllowed:
+          cpu: "{{ .Values.snapshotter.vpa.maxAllowed.cpu }}"
+          memory: "{{ .Values.snapshotter.vpa.maxAllowed.memory }}"
+        controlledResources: ["cpu", "memory"]
+      - containerName: 'csi-resizer'
+        minAllowed:
+          cpu: "{{ .Values.resizer.vpa.minAllowed.cpu }}"
+          memory: "{{ .Values.resizer.vpa.minAllowed.memory }}"
+        maxAllowed:
+          cpu: "{{ .Values.resizer.vpa.maxAllowed.cpu }}"
+          memory: "{{ .Values.resizer.vpa.maxAllowed.memory }}"
+        controlledResources: ["cpu", "memory"]
+{{- end}}

--- a/src/test/csi-qingcloud/templates/vpa.yaml
+++ b/src/test/csi-qingcloud/templates/vpa.yaml
@@ -3,7 +3,7 @@
 apiVersion: "autoscaling.k8s.io/v1"
 kind: VerticalPodAutoscaler
 metadata:
-  name: csi-qingcloud-vpa
+  name: csi-qingcloud-controller-vpa
   namespace: kube-system
 spec:
   targetRef:

--- a/src/test/csi-qingcloud/values.yaml
+++ b/src/test/csi-qingcloud/values.yaml
@@ -52,6 +52,13 @@ controller:
     requests:
       memory: 100Mi
       cpu: 100m
+  vpa:
+    minAllowed:
+      cpu: 100m
+      memory: 100Mi
+    maxAllowed:
+      cpu: 1
+      memory: 1000Mi
 provisioner:
   repository: csiplugin/csi-provisioner
   tag: v2.2.2
@@ -63,6 +70,13 @@ provisioner:
     requests:
       memory: 100Mi
       cpu: 100m
+  vpa:
+    minAllowed:
+      cpu: 20m
+      memory: 50Mi
+    maxAllowed:
+      cpu: 200m
+      memory: 200Mi
 attacher:
   repository: csiplugin/csi-attacher
   tag: v3.2.1
@@ -73,26 +87,47 @@ attacher:
     requests:
       memory: 100Mi
       cpu: 100m
+  vpa:
+    minAllowed:
+      cpu: 20m
+      memory: 50Mi
+    maxAllowed:
+      cpu: 200m
+      memory: 200Mi
 resizer:
   repository: csiplugin/csi-resizer
   tag: v1.2.0
   resources:
     limits:
-      memory: 40Mi
-      cpu: 20m
+      memory: 100Mi
+      cpu: 100m
     requests:
-      memory: 40Mi
+      memory: 100Mi
+      cpu: 100m
+  vpa:
+    minAllowed:
       cpu: 20m
+      memory: 50Mi
+    maxAllowed:
+      cpu: 200m
+      memory: 200Mi
 snapshotter:
   repository: csiplugin/csi-snapshotter
   tag: v4.0.0
   resources:
     limits:
-      memory: 40Mi
-      cpu: 20m
+      memory: 100Mi
+      cpu: 100m
     requests:
-      memory: 40Mi
+      memory: 100Mi
+      cpu: 100m
+  vpa:
+    minAllowed:
       cpu: 20m
+      memory: 50Mi
+    maxAllowed:
+      cpu: 200m
+      memory: 200Mi
 
 registrar:
   repository: csiplugin/csi-node-driver-registrar
@@ -124,3 +159,5 @@ sc:
   reclaimPolicy: Delete
   allowVolumeExpansion: true
   volumeBindingMode: WaitForFirstConsumer
+
+enableVPA: false

--- a/src/test/csi-qingcloud/values.yaml
+++ b/src/test/csi-qingcloud/values.yaml
@@ -27,7 +27,6 @@ config:
 driver:
   name: disk.csi.qingcloud.com
   repository: csiplugin/csi-qingcloud
-  # tag:
   pullPolicy: IfNotPresent
   maxVolume: 9
   retryDetachTimesMax: 100

--- a/src/test/csi-qingcloud/values.yaml
+++ b/src/test/csi-qingcloud/values.yaml
@@ -75,8 +75,8 @@ provisioner:
       cpu: 20m
       memory: 50Mi
     maxAllowed:
-      cpu: 200m
-      memory: 200Mi
+      cpu: 1
+      memory: 1000Mi
 attacher:
   repository: csiplugin/csi-attacher
   tag: v3.2.1
@@ -92,8 +92,8 @@ attacher:
       cpu: 20m
       memory: 50Mi
     maxAllowed:
-      cpu: 200m
-      memory: 200Mi
+      cpu: 1
+      memory: 1000Mi
 resizer:
   repository: csiplugin/csi-resizer
   tag: v1.2.0
@@ -109,8 +109,8 @@ resizer:
       cpu: 20m
       memory: 50Mi
     maxAllowed:
-      cpu: 200m
-      memory: 200Mi
+      cpu: 1
+      memory: 1000Mi
 snapshotter:
   repository: csiplugin/csi-snapshotter
   tag: v4.0.0
@@ -126,8 +126,8 @@ snapshotter:
       cpu: 20m
       memory: 50Mi
     maxAllowed:
-      cpu: 200m
-      memory: 200Mi
+      cpu: 1
+      memory: 1000Mi
 
 registrar:
   repository: csiplugin/csi-node-driver-registrar


### PR DESCRIPTION
add VPA yaml and CHANGELOG.
update README.md, add a note about vpa.
After testing, when the resource of the container is equal to vpa.minallowed, csi-qingcloudcontroller is available. 
And when the resources are not enough, vpa will start autoscale.
Signed-off-by: f10atin9 <f10atin9@kubesphere.io>