### PR TITLE
Add InAccel FPGA Operator

### DIFF
--- a/src/stable/fpga-operator/Chart.lock
+++ b/src/stable/fpga-operator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: node-feature-discovery
+  repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+  version: 0.9.0
+digest: sha256:8a6feace87ead9cd3f93e78b26ba11a47bd7155f6e5fa7faeb6bdbaed50a18a5
+generated: "2021-11-16T21:35:13.145288325Z"

--- a/src/stable/fpga-operator/Chart.yaml
+++ b/src/stable/fpga-operator/Chart.yaml
@@ -1,4 +1,6 @@
 annotations:
+  app.kubesphere.io/category: Infrastructure
+  app.kubesphere.io/display-name: InAccel FPGA Operator
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Documentation

--- a/src/stable/fpga-operator/Chart.yaml
+++ b/src/stable/fpga-operator/Chart.yaml
@@ -1,0 +1,30 @@
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://docs.inaccel.com
+  category: Infrastructure
+apiVersion: v2
+appVersion: "2.1"
+dependencies:
+- alias: fpga-discovery
+  condition: fpga-discovery.enabled
+  name: node-feature-discovery
+  repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+  version: 0.9.0
+description: Simplifying FPGA management in Kubernetes
+home: https://inaccel.com
+icon: https://en.gravatar.com/userimage/147236320/2a11cd2992b4521ec287587f03fae35c.png?size=1250
+keywords:
+- fpga
+- infrastructure
+kubeVersion: '>= 1.18.0-0'
+maintainers:
+- email: info@inaccel.com
+  name: InAccel
+name: fpga-operator
+sources:
+- https://docs.inaccel.com
+- https://github.com/inaccel/helm
+type: application
+version: 2.6.1

--- a/src/stable/fpga-operator/README.md
+++ b/src/stable/fpga-operator/README.md
@@ -1,0 +1,81 @@
+# InAccel FPGA Operator
+
+Simplifying FPGA management in Kubernetes
+
+## Installing the Chart
+
+To install the chart with the release name `my-fpga-operator`:
+
+```console
+$ helm repo add inaccel https://setup.inaccel.com/helm
+$ helm install my-fpga-operator inaccel/fpga-operator
+```
+
+These commands deploy InAccel FPGA Operator on the Kubernetes cluster in the
+default configuration.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-fpga-operator` deployment:
+
+```console
+$ helm uninstall my-fpga-operator
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the InAccel FPGA
+Operator chart and their default values.
+
+| Parameter            | Default            |
+| -------------------- | ------------------ |
+| `coral.httpsProxy`   |                    |
+| `coral.image`        | `inaccel/coral`    |
+| `coral.logLevel`     | `info`             |
+| `coral.port`         |                    |
+| `coral.pullPolicy`   | `Always`           |
+| `coral.resources`    |                    |
+| `coral.tag`          | *APP VERSION*      |
+| `daemon.debug`       | `false`            |
+| `daemon.image`       | `inaccel/daemon`   |
+| `daemon.pullPolicy`  |                    |
+| `daemon.resources`   |                    |
+| `daemon.tag`         | `latest`           |
+| `driver.enabled`     | `true`             |
+| `driver.image`       | `inaccel/driver`   |
+| `driver.pullPolicy`  |                    |
+| `driver.tag`         | `latest`           |
+| `kubelet`            | `/var/lib/kubelet` |
+| `license`            |                    |
+| `mkrt.image`         | `inaccel/mkrt`     |
+| `mkrt.pullPolicy`    |                    |
+| `mkrt.tag`           | `latest`           |
+| `monitor.image`      | `inaccel/monitor`  |
+| `monitor.port`       |                    |
+| `monitor.pullPolicy` | `Always`           |
+| `monitor.resources`  |                    |
+| `monitor.tag`        | *APP VERSION*      |
+| `reef.debug`         | `false`            |
+| `reef.image`         | `inaccel/reef`     |
+| `reef.pullPolicy`    |                    |
+| `reef.resources`     |                    |
+| `reef.tag`           | `latest`           |
+| `root.config`        | `/etc/inaccel`     |
+| `root.state`         | `/var/lib/inaccel` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
+
+```console
+$ helm install my-fpga-operator -f values.yaml inaccel/fpga-operator
+```
+
+> **Tip**: You can use the default `values.yaml`

--- a/src/stable/fpga-operator/charts/node-feature-discovery/.helmignore
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/stable/fpga-operator/charts/node-feature-discovery/Chart.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+appVersion: v0.9.0
+description: 'Detects hardware features available on each node in a Kubernetes cluster,
+  and advertises those features using node labels. '
+home: https://github.com/kubernetes-sigs/node-feature-discovery
+keywords:
+- feature-discovery
+- feature-detection
+- node-labels
+name: node-feature-discovery
+sources:
+- https://github.com/kubernetes-sigs/node-feature-discovery
+type: application
+version: 0.9.0

--- a/src/stable/fpga-operator/charts/node-feature-discovery/README.md
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/README.md
@@ -1,0 +1,10 @@
+# Node Feature Discovery
+
+Node Feature Discovery (NFD) is a Kubernetes add-on for detecting hardware
+features and system configuration. Detected features are advertised as node
+labels. NFD provides flexible configuration and extension points for a wide
+range of vendor and application specific node labeling needs.
+
+See
+[NFD documentation](https://kubernetes-sigs.github.io/node-feature-discovery/v0.9/get-started/deployment-and-usage.html#deployment-with-helm)
+for deployment instructions.

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/_helpers.tpl
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-feature-discovery.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-feature-discovery.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-feature-discovery.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "node-feature-discovery.labels" -}}
+helm.sh/chart: {{ include "node-feature-discovery.chart" . }}
+{{ include "node-feature-discovery.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "node-feature-discovery.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node-feature-discovery.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "node-feature-discovery.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "node-feature-discovery.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/clusterrole.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  # when using command line flag --resource-labels to create extended resources
+  # you will need to uncomment "- nodes/status"
+  # - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
+{{- end }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "node-feature-discovery.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/master.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/master.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "node-feature-discovery.fullname" . }}-master
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: master
+spec:
+  replicas: {{ .Values.master.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
+      role: master
+  template:
+    metadata:
+      labels:
+        {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
+        role: master
+      annotations:
+        {{- toYaml .Values.master.annotations | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "node-feature-discovery.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.master.podSecurityContext | nindent 8 }}
+      containers:
+        - name: master
+          securityContext:
+            {{- toYaml .Values.master.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/usr/bin/grpc_health_probe", "-addr=:8080"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 10
+          ports:
+          - containerPort: 8080
+            name: grpc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          command:
+            - "nfd-master"
+          resources:
+            {{- toYaml .Values.master.resources | nindent 12 }}
+          args:
+            {{- if .Values.master.instance | empty | not }}
+            - "--instance={{ .Values.master.instance }}"
+            {{- end }}
+            {{- if .Values.master.extraLabelNs | empty | not }}
+            - "--extra-label-ns={{- join "," .Values.master.extraLabelNs }}"
+            {{- end }}
+## Enable TLS authentication
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-master-cert.
+## Additional hardening can be enabled by specifying --verify-node-name in
+## args, in which case node name will be checked against the worker's
+## TLS certificate.
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+#          volumeMounts:
+#            - name: nfd-ca-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#              readOnly: true
+#            - name: nfd-master-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#              readOnly: true
+#      volumes:
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-master-cert
+#          secret:
+#            secretName: nfd-master-cert
+    {{- with .Values.master.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.master.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.master.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.worker.configmapName }}
+  labels:
+  {{- include "node-feature-discovery.labels" . | nindent 4 }}
+data:
+  nfd-worker.conf: |-
+    {{- .Values.worker.config | nindent 4 }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/service.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "node-feature-discovery.fullname" . }}-master
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: master
+spec:
+  type: {{ .Values.master.service.type }}
+  ports:
+    - port: {{ .Values.master.service.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "node-feature-discovery.selectorLabels" . | nindent 4 }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-feature-discovery.serviceAccountName" . }}
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/templates/worker.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/templates/worker.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name:  {{ include "node-feature-discovery.fullname" . }}-worker
+  labels:
+    {{- include "node-feature-discovery.labels" . | nindent 4 }}
+    role: worker
+spec:
+  selector:
+    matchLabels:
+      {{- include "node-feature-discovery.selectorLabels" . | nindent 6 }}
+      role: worker
+  template:
+    metadata:
+      labels:
+        {{- include "node-feature-discovery.selectorLabels" . | nindent 8 }}
+        role: worker
+      annotations:
+        {{- toYaml .Values.worker.annotations | nindent 8 }}
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
+      containers:
+      - name: worker
+        securityContext:
+          {{- toYaml .Values.worker.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+        {{- toYaml .Values.worker.resources | nindent 12 }}
+        command:
+        - "nfd-worker"
+        args:
+        - "--sleep-interval=60s"
+        - "--server={{ include "node-feature-discovery.fullname" . }}-master:{{ .Values.master.service.port }}"
+## Enable TLS authentication (1/3)
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-worker-cert
+#          - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+        volumeMounts:
+        - name: host-boot
+          mountPath: "/host-boot"
+          readOnly: true
+        - name: host-os-release
+          mountPath: "/host-etc/os-release"
+          readOnly: true
+        - name: host-sys
+          mountPath: "/host-sys"
+          readOnly: true
+        - name: host-usr-lib
+          mountPath: "/host-usr/lib"
+          readOnly: true
+        - name: host-usr-src
+          mountPath: "/host-usr/src"
+          readOnly: true
+        - name: source-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+          readOnly: true
+        - name: features-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+          readOnly: true
+        - name: nfd-worker-conf
+          mountPath: "/etc/kubernetes/node-feature-discovery"
+          readOnly: true
+## Enable TLS authentication (2/3)
+#        - name: nfd-ca-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#          readOnly: true
+#        - name: nfd-worker-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#          readOnly: true
+      volumes:
+        - name: host-boot
+          hostPath:
+            path: "/boot"
+        - name: host-os-release
+          hostPath:
+            path: "/etc/os-release"
+        - name: host-sys
+          hostPath:
+            path: "/sys"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"
+        - name: source-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - name: features-d
+          hostPath:
+            path: "/etc/kubernetes/node-feature-discovery/features.d/"
+        - name: nfd-worker-conf
+          configMap:
+            name: {{ .Values.worker.configmapName }}
+            items:
+              - key: nfd-worker.conf
+                path: nfd-worker.conf
+## Enable TLS authentication (3/3)
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-worker-cert
+#          secret:
+#            secretName: nfd-worker-cert
+    {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/src/stable/fpga-operator/charts/node-feature-discovery/values.yaml
+++ b/src/stable/fpga-operator/charts/node-feature-discovery/values.yaml
@@ -1,0 +1,235 @@
+image:
+  repository: k8s.gcr.io/nfd/node-feature-discovery
+  # This should be set to 'IfNotPresent' for released version
+  pullPolicy: IfNotPresent
+  # tag, if defined will use the given image tag, else Chart.AppVersion will be used
+  # tag
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+nameOverride: ""
+fullnameOverride: ""
+
+master:
+  instance:
+  extraLabelNs: []
+
+  replicaCount: 1
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations:
+  - key: "node-role.kubernetes.io/master"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+
+  annotations: {}
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [""]
+
+worker:
+  configmapName: nfd-worker-conf
+  config: |### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
+    #core:
+    #  labelWhiteList:
+    #  noPublish: false
+    #  sleepInterval: 60s
+    #  sources: [all]
+    #  klog:
+    #    addDirHeader: false
+    #    alsologtostderr: false
+    #    logBacktraceAt:
+    #    logtostderr: true
+    #    skipHeaders: false
+    #    stderrthreshold: 2
+    #    v: 0
+    #    vmodule:
+    ##   NOTE: the following options are not dynamically run-time configurable
+    ##         and require a nfd-worker restart to take effect after being changed
+    #    logDir:
+    #    logFile:
+    #    logFileMaxSize: 1800
+    #    skipLogHeaders: false
+    #sources:
+    #  cpu:
+    #    cpuid:
+    ##     NOTE: whitelist has priority over blacklist
+    #      attributeBlacklist:
+    #        - "BMI1"
+    #        - "BMI2"
+    #        - "CLMUL"
+    #        - "CMOV"
+    #        - "CX16"
+    #        - "ERMS"
+    #        - "F16C"
+    #        - "HTT"
+    #        - "LZCNT"
+    #        - "MMX"
+    #        - "MMXEXT"
+    #        - "NX"
+    #        - "POPCNT"
+    #        - "RDRAND"
+    #        - "RDSEED"
+    #        - "RDTSCP"
+    #        - "SGX"
+    #        - "SSE"
+    #        - "SSE2"
+    #        - "SSE3"
+    #        - "SSE4"
+    #        - "SSE42"
+    #        - "SSSE3"
+    #      attributeWhitelist:
+    #  kernel:
+    #    kconfigFile: "/path/to/kconfig"
+    #    configOpts:
+    #      - "NO_HZ"
+    #      - "X86"
+    #      - "DMI"
+    #  pci:
+    #    deviceClassWhitelist:
+    #      - "0200"
+    #      - "03"
+    #      - "12"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #      - "subsystem_vendor"
+    #      - "subsystem_device"
+    #  usb:
+    #    deviceClassWhitelist:
+    #      - "0e"
+    #      - "ef"
+    #      - "fe"
+    #      - "ff"
+    #    deviceLabelFields:
+    #      - "class"
+    #      - "vendor"
+    #      - "device"
+    #  custom:
+    #    - name: "my.kernel.feature"
+    #      matchOn:
+    #        - loadedKMod: ["example_kmod1", "example_kmod2"]
+    #    - name: "my.pci.feature"
+    #      matchOn:
+    #        - pciId:
+    #            class: ["0200"]
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #        - pciId :
+    #            vendor: ["8086"]
+    #            device: ["1000", "1100"]
+    #    - name: "my.usb.feature"
+    #      matchOn:
+    #        - usbId:
+    #          class: ["ff"]
+    #          vendor: ["03e7"]
+    #          device: ["2485"]
+    #        - usbId:
+    #          class: ["fe"]
+    #          vendor: ["1a6e"]
+    #          device: ["089a"]
+    #    - name: "my.combined.feature"
+    #      matchOn:
+    #        - pciId:
+    #            vendor: ["15b3"]
+    #            device: ["1014", "1017"]
+    #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
+    #    - name: "feature.by.nodename"
+    #      value: customValue
+    #      matchOn:
+    #        - nodename: ["worker-0", "my-.*-node"]
+### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  annotations: {}
+
+## RBAC parameteres
+## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+##
+rbac:
+  create: true
+  serviceAccountName:
+  ## Annotations for the Service Account
+  ##
+  serviceAccountAnnotations: {}

--- a/src/stable/fpga-operator/templates/NOTES.txt
+++ b/src/stable/fpga-operator/templates/NOTES.txt
@@ -1,0 +1,9 @@
+{{- if .Release.IsInstall -}}
+Install
+{{- end -}}
+{{- if .Release.IsUpgrade -}}
+Upgrad
+{{- end -}}
+ing {{ ( index .Chart.Maintainers 0 ).Name }} [{{ include "chart" . }}] {{ .Release.Service }} chart.
+For detailed usage instructions visit: {{ index .Chart.Sources 0 }}
+For more product information contact: {{ ( index .Chart.Maintainers 0 ).Email }}

--- a/src/stable/fpga-operator/templates/_helpers.tpl
+++ b/src/stable/fpga-operator/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels" -}}
+helm.sh/chart: {{ include "chart" . }}
+{{ include "selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/src/stable/fpga-operator/templates/cluster-role-binding.yaml
+++ b/src/stable/fpga-operator/templates/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/src/stable/fpga-operator/templates/cluster-role.yaml
+++ b/src/stable/fpga-operator/templates/cluster-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "update"]

--- a/src/stable/fpga-operator/templates/csi-driver.yaml
+++ b/src/stable/fpga-operator/templates/csi-driver.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: inaccel
+spec:
+  attachRequired: false
+  volumeLifecycleModes:
+  - Ephemeral

--- a/src/stable/fpga-operator/templates/daemon-set.yaml
+++ b/src/stable/fpga-operator/templates/daemon-set.yaml
@@ -1,0 +1,185 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      kind: DaemonSet
+      {{- include "selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: coral
+      labels:
+        kind: DaemonSet
+        {{- include "labels" . | nindent 8 }}
+    spec:
+      containers:
+      - env:
+        {{- if .Values.coral.httpsProxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.coral.httpsProxy }}
+        {{- end }}
+        {{- if .Values.license }}
+        - name: LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license
+              name: {{ .Chart.Name }}
+        {{- end }}
+        {{- if .Values.coral.logLevel }}
+        - name: LOG_LEVEL
+          value: {{ .Values.coral.logLevel }}
+        {{- end }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: {{ .Values.coral.image }}:{{ default .Chart.AppVersion .Values.coral.tag }}
+        {{- if .Values.coral.pullPolicy }}
+        imagePullPolicy: {{ .Values.coral.pullPolicy }}
+        {{- end }}
+        name: coral
+        ports:
+        - containerPort: 55677
+          {{- if .Values.coral.port }}
+          hostPort: {{ .Values.coral.port }}
+          {{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - get
+            - coral
+        {{- if .Values.coral.resources }}
+        resources:
+          {{- .Values.coral.resources | toYaml | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/localtime
+          name: localtime
+          readOnly: true
+        - mountPath: /sys
+          name: sys
+        - mountPath: /var/lib/inaccel
+          mountPropagation: HostToContainer
+          name: state-root
+        - mountPath: /var/lib/kubelet/plugins_registry
+          name: kubelet
+          subPath: plugins_registry
+        - mountPath: /var/opt/inaccel/runtimes
+          name: data-root
+          readOnly: true
+          subPath: runtimes
+      - args:
+        - --debug={{ .Values.daemon.debug }}
+        env:
+        - name: DOCKER
+          value: disabled
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: {{ .Values.daemon.image }}:{{ .Values.daemon.tag }}
+        {{- if .Values.daemon.pullPolicy }}
+        imagePullPolicy: {{ .Values.daemon.pullPolicy }}
+        {{- end }}
+        name: daemon
+        {{- if .Values.daemon.resources }}
+        resources:
+          {{- .Values.daemon.resources | toYaml | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/inaccel
+          mountPropagation: Bidirectional
+          name: state-root
+        - mountPath: /var/lib/kubelet/plugins_registry
+          name: kubelet
+          subPath: plugins_registry
+        - mountPath: {{ .Values.kubelet }}
+          mountPropagation: Bidirectional
+          name: kubelet
+      - image: {{ .Values.monitor.image }}:{{ default .Chart.AppVersion .Values.monitor.tag }}
+        {{- if .Values.monitor.pullPolicy }}
+        imagePullPolicy: {{ .Values.monitor.pullPolicy }}
+        {{- end }}
+        name: monitor
+        ports:
+        - containerPort: 19999
+          {{- if .Values.monitor.port }}
+          hostPort: {{ .Values.monitor.port }}
+          {{- end }}
+        {{- if .Values.monitor.resources }}
+        resources:
+          {{- .Values.monitor.resources | toYaml | nindent 10 }}
+        {{- end }}
+      hostAliases:
+      - hostnames:
+        - coral
+        - daemon
+        - monitor
+        ip: 127.0.0.1
+      hostPID: {{ .Values.driver.enabled }}
+      initContainers:
+      {{- if .Values.driver.enabled }}
+      - env:
+        - name: DRIVER_SYSROOT_DIR
+          value: /host
+        image: {{ .Values.driver.image }}:{{ .Values.driver.tag }}
+        {{- if .Values.driver.pullPolicy }}
+        imagePullPolicy: {{ .Values.driver.pullPolicy }}
+        {{- end }}
+        name: driver
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host
+          name: host
+      {{- end }}
+      - env:
+        - name: MKRT_CONFIG_PATH
+          value: {{ .Values.root.config }}/runtimes
+        - name: MKRT_SYSROOT_DIR
+          value: /host
+        image: {{ .Values.mkrt.image }}:{{ .Values.mkrt.tag }}
+        {{- if .Values.mkrt.pullPolicy }}
+        imagePullPolicy: {{ .Values.mkrt.pullPolicy }}
+        {{- end }}
+        name: mkrt
+        volumeMounts:
+        - mountPath: /host
+          name: host
+          readOnly: true
+        - mountPath: /var/opt/inaccel/runtimes
+          name: data-root
+          subPath: runtimes
+      nodeSelector:
+        inaccel/fpga: enabled
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ .Chart.Name }}
+      volumes:
+      - emptyDir: {}
+        name: data-root
+      - hostPath:
+          path: /
+        name: host
+      - hostPath:
+          path: {{ .Values.kubelet }}
+        name: kubelet
+      - hostPath:
+          path: /etc/localtime
+        name: localtime
+      - hostPath:
+          path: {{ .Values.root.state }}
+          type: DirectoryOrCreate
+        name: state-root
+      - hostPath:
+          path: /sys
+        name: sys

--- a/src/stable/fpga-operator/templates/deployment.yaml
+++ b/src/stable/fpga-operator/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kind: Deployment
+      {{- include "selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: reef
+      labels:
+        kind: Deployment
+        {{- include "labels" . | nindent 8 }}
+    spec:
+      containers:
+      - args:
+        - --debug={{ .Values.reef.debug }}
+        image: {{ .Values.reef.image }}:{{ .Values.reef.tag }}
+        {{- if .Values.reef.pullPolicy }}
+        imagePullPolicy: {{ .Values.reef.pullPolicy }}
+        {{- end }}
+        name: reef
+        {{- if .Values.reef.resources }}
+        resources:
+          {{- .Values.reef.resources | toYaml | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /etc/inaccel
+          name: config-root
+          readOnly: true
+      hostAliases:
+      - hostnames:
+        - reef
+        ip: 127.0.0.1
+      initContainers:
+      - args:
+        - init
+        env:
+        - name: MUTATING_WEBHOOK_CONFIGURATION_NAME
+          value: {{ .Chart.Name }}
+        image: {{ .Values.reef.image }}:{{ .Values.reef.tag }}
+        {{- if .Values.reef.pullPolicy }}
+        imagePullPolicy: {{ .Values.reef.pullPolicy }}
+        {{- end }}
+        name: reef-init
+        volumeMounts:
+        - mountPath: /etc/inaccel
+          name: config-root
+      priorityClassName: system-cluster-critical
+      serviceAccountName: {{ .Chart.Name }}
+      volumes:
+      - emptyDir: {}
+        name: config-root

--- a/src/stable/fpga-operator/templates/mutating-webhook-configuration.yaml
+++ b/src/stable/fpga-operator/templates/mutating-webhook-configuration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+webhooks:
+- admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: {{ .Chart.Name }}
+      namespace: {{ .Release.Namespace }}
+  name: reef.inaccel.com
+  objectSelector:
+    matchLabels:
+      inaccel/fpga: enabled
+  sideEffects: None

--- a/src/stable/fpga-operator/templates/secret.yaml
+++ b/src/stable/fpga-operator/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{- if .Values.license }}
+  license: {{ .Values.license }}
+  {{- end }}
+type: Opaque

--- a/src/stable/fpga-operator/templates/service-account.yaml
+++ b/src/stable/fpga-operator/templates/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/src/stable/fpga-operator/templates/service.yaml
+++ b/src/stable/fpga-operator/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+  publishNotReadyAddresses: true
+  selector:
+    kind: Deployment
+    {{- include "selectorLabels" . | nindent 4 }}

--- a/src/stable/fpga-operator/values.yaml
+++ b/src/stable/fpga-operator/values.yaml
@@ -1,0 +1,78 @@
+coral:
+  # httpsProxy: ...
+  image: inaccel/coral
+  logLevel: info
+  # port: ...
+  pullPolicy: Always
+  # resources: ...
+  # tag: ...
+
+daemon:
+  debug: false
+  image: inaccel/daemon
+  # pullPolicy: ...
+  # resources: ...
+  tag: latest
+
+driver:
+  enabled: true
+  image: inaccel/driver
+  # pullPolicy: ...
+  tag: latest
+
+fpga-discovery:
+  enabled: true
+  fullnameOverride: fpga-discovery
+  image:
+    tag: v0.9.0-minimal
+  master:
+    extraLabelNs:
+    - inaccel
+  worker:
+    config: |
+      core:
+        sources:
+        - custom
+      sources:
+        custom:
+        - matchOn:
+          # intel-fpga
+          - pciId:
+              device: ["09c4", "0b2b"]
+              vendor: ["8086"]
+          # xilinx-fpga
+          - pciId:
+              vendor: ["10ee"]
+          - pciId:
+              device: ["1042", "f010"]
+              vendor: ["1d0f"]
+          name: inaccel/fpga
+          value: enabled
+    configmapName: fpga-discovery
+
+kubelet: /var/lib/kubelet
+
+# license: ...
+
+mkrt:
+  image: inaccel/mkrt
+  # pullPolicy: ...
+  tag: latest
+
+monitor:
+  image: inaccel/monitor
+  # port: ...
+  pullPolicy: Always
+  # resources: ...
+  # tag: ...
+
+reef:
+  debug: false
+  image: inaccel/reef
+  # pullPolicy: ...
+  # resources: ...
+  tag: latest
+
+root:
+  config: /etc/inaccel
+  state: /var/lib/inaccel


### PR DESCRIPTION
## Simplifying FPGA management in KubeSphere

### App Introduction

[InAccel FPGA Operator](https://artifacthub.io/packages/helm/inaccel/fpga-operator) is a cloud-native method to standardize and automate the deployment of all the necessary components for provisioning FPGA-enabled Kubernetes systems. FPGA Operator delivers a universal accelerator orchestration and monitoring layer, to automate scalability and lifecycle management of containerized FPGA applications on any Kubernetes cluster.

The FPGA operator also allows cluster admins to manage their remote FPGA-powered servers the same way they manage CPU-based systems, but also regular users to target particular FPGA types and explicitly consume FPGA resources in their workloads. This makes it easy to bring up a fleet of remote systems and run accelerated applications without additional technical expertise on the ground.