### PR TITLE
Revert "change the name of JH helm charts."

### DIFF
--- a/src/stable/jh/Chart.yaml
+++ b/src/stable/jh/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 maintainers:
 - email: support@gitlab.cn
   name: JiHu(GitLab)
-name: JiHu GitLab
+name: gitlab
 sources:
 - https://jihulab.com/gitlab-cn/charts/gitlab
 version: 5.8.2


### PR DESCRIPTION
This reverts commit 13a96176b5d9560c81efb7e39dac58c305f82a84.
The name of the chart will be added to the labels. And labels can't contain the capital characters.

/cc @zheng1 