### PR TITLE
Upgrade juicefs chart to v0.13.2

### DIFF
--- a/src/stable/juicefs/Chart.yaml
+++ b/src/stable/juicefs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: juicefs
 description: A Helm chart for JuiceFS CSI Driver
 type: application
-version: 0.7.0
-appVersion: 0.11.0
+version: 0.9.2
+appVersion: 0.13.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/juicedata/juicefs
 sources:

--- a/src/stable/juicefs/README.md
+++ b/src/stable/juicefs/README.md
@@ -1,6 +1,6 @@
 # juicefs-csi-driver
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.2](https://img.shields.io/badge/AppVersion-0.13.2-informational?style=flat-square)
 
 A Helm chart for JuiceFS CSI Driver
 
@@ -16,40 +16,38 @@ Kubernetes: `>=1.14.0-0`
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| controller.affinity | object | Hard node and soft zone anti-affinity | Affinity for controller pods. |
-| controller.enabled | bool | `true` |  |
-| controller.nodeSelector | object | `{}` | Node selector for controller pods |
-| controller.replicas | int | `1` |  |
-| controller.resources.limits.cpu | string | `"1000m"` |  |
-| controller.resources.limits.memory | string | `"1Gi"` |  |
-| controller.resources.requests.cpu | string | `"100m"` |  |
-| controller.resources.requests.memory | string | `"512Mi"` |  |
-| controller.service.port | int | `9909` |  |
-| controller.service.trpe | string | `"ClusterIP"` |  |
-| controller.terminationGracePeriodSeconds | int | `30` | Grace period to allow the controller to shutdown before it is killed |
+| Key | Type | Default                                              | Description |
+|-----|------|------------------------------------------------------|-------------|
+| controller.affinity | object | Hard node and soft zone anti-affinity                | Affinity for controller pods. |
+| controller.enabled | bool | `true`                                               |  |
+| controller.nodeSelector | object | `{}`                                                 | Node selector for controller pods |
+| controller.replicas | int | `1`                                                  |  |
+| controller.resources.limits.cpu | string | `"1000m"`                                            |  |
+| controller.resources.limits.memory | string | `"1Gi"`                                              |  |
+| controller.resources.requests.cpu | string | `"100m"`                                             |  |
+| controller.resources.requests.memory | string | `"512Mi"`                                            |  |
+| controller.service.port | int | `9909`                                               |  |
+| controller.service.trpe | string | `"ClusterIP"`                                        |  |
+| controller.terminationGracePeriodSeconds | int | `30`                                                 | Grace period to allow the controller to shutdown before it is killed |
 | controller.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations for controller pods |
-| dnsConfig | object | `{}` |  |
-| dnsPolicy | string | `"ClusterFirstWithHostNet"` |  |
-| hostAliases | list | `[]` |  |
-| image.pullPolicy | string | `""` |  |
-| image.repository | string | `"juicedata/juicefs-csi-driver"` |  |
-| image.tag | string | `"v0.10.5"` |  |
-| jfsConfigDir | string | `"/var/lib/juicefs/config"` |  |
-| jfsMountDir | string | `"/var/lib/juicefs/volume"` | juicefs mount dir |
-| jfsMountPriority | object | `{"enable":true,"name":"juicefs-mount-critical"}` | juicefs mount pod priority |
-| kubeletDir | string | `"/var/lib/kubelet"` | kubelet working directory,can be set using `--root-dir` when starting kubelet |
-| namespace | string | `"kube-system"` |  |
-| node.affinity | object | Hard node and soft zone anti-affinity | Affinity for node pods. |
-| node.enabled | bool | `true` |  |
-| node.hostNetwork | bool | `false` |  |
-| node.nodeSelector | object | `{}` | Node selector for node pods |
-| node.resources.limits.cpu | string | `"2000m"` |  |
-| node.resources.limits.memory | string | `"5Gi"` |  |
-| node.resources.requests.cpu | string | `"1000m"` |  |
-| node.resources.requests.memory | string | `"1Gi"` |  |
-| node.terminationGracePeriodSeconds | int | `30` | Grace period to allow the node pod to shutdown before it is killed |
+| dnsConfig | object | `{}`                                                 |  |
+| dnsPolicy | string | `"ClusterFirstWithHostNet"`                          |  |
+| hostAliases | list | `[]`                                                 |  |
+| image.pullPolicy | string | `""`                                                 |  |
+| image.repository | string | `"juicedata/juicefs-csi-driver"`                     |  |
+| image.tag | string | `"v0.13.2"`                                          |  |
+| jfsConfigDir | string | `"/var/lib/juicefs/config"`                          |  |
+| jfsMountDir | string | `"/var/lib/juicefs/volume"`                          | juicefs mount dir |
+| kubeletDir | string | `"/var/lib/kubelet"`                                 | kubelet working directory,can be set using `--root-dir` when starting kubelet |
+| node.affinity | object | Hard node and soft zone anti-affinity                | Affinity for node pods. |
+| node.enabled | bool | `true`                                               |  |
+| node.hostNetwork | bool | `false`                                              |  |
+| node.nodeSelector | object | `{}`                                                 | Node selector for node pods |
+| node.resources.limits.cpu | string | `"2000m"`                                            |  |
+| node.resources.limits.memory | string | `"5Gi"`                                              |  |
+| node.resources.requests.cpu | string | `"1000m"`                                            |  |
+| node.resources.requests.memory | string | `"1Gi"`                                              |  |
+| node.terminationGracePeriodSeconds | int | `30`                                                 | Grace period to allow the node pod to shutdown before it is killed |
 | node.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations for node pods |
 | serviceAccount.controller.annotations | object | `{}` |  |
 | serviceAccount.controller.create | bool | `true` |  |

--- a/src/stable/juicefs/templates/controller.yaml
+++ b/src/stable/juicefs/templates/controller.yaml
@@ -33,7 +33,7 @@ spec:
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --logtostderr
-        - --nodeid=$(NODE_ID)
+        - --nodeid=$(NODE_NAME)
         - --v=5
         env:
         - name: CSI_ENDPOINT

--- a/src/stable/juicefs/templates/daemonset.yaml
+++ b/src/stable/juicefs/templates/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --logtostderr
-        - --nodeid=$(NODE_ID)
+        - --nodeid=$(NODE_NAME)
         - --v=5
         - --enable-manager=true
         env:
@@ -49,6 +49,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: KUBELET_PORT
+          value: "10250"
         - name: JUICEFS_MOUNT_PATH
           value: {{ .Values.jfsMountDir }}
         - name: JUICEFS_CONFIG_PATH

--- a/src/stable/juicefs/templates/serviceaccount.yaml
+++ b/src/stable/juicefs/templates/serviceaccount.yaml
@@ -60,6 +60,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/log
   verbs:
   - get
   - list
@@ -91,6 +92,22 @@ rules:
   verbs:
   - get
   - list
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -139,6 +156,36 @@ rules:
       - ""
     resources:
       - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - get
       - list

--- a/src/stable/juicefs/templates/storageclass.yaml
+++ b/src/stable/juicefs/templates/storageclass.yaml
@@ -26,6 +26,15 @@ data:
   {{- if .bucket }}
   bucket: {{ .bucket | b64enc | quote }}
   {{- end }}
+  {{- if .envs }}
+  envs: {{ .envs | b64enc | quote }}
+  {{- end }}
+  {{- if .configs }}
+  configs: {{ .configs | b64enc | quote }}
+  {{- end }}
+  {{- if .trashDays }}
+  trash-days: {{ .trashDays | b64enc | quote }}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: storage.k8s.io/v1

--- a/src/stable/juicefs/values.yaml
+++ b/src/stable/juicefs/values.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: juicedata/juicefs-csi-driver
-  tag: "v0.11.0"
+  tag: "v0.13.2"
   pullPolicy: ""
 
 sidecars:
@@ -134,10 +134,20 @@ storageClasses:
     secretKey: ""
     # -- Bucket URL. Read [this document](https://github.com/juicedata/juicefs/blob/main/docs/en/how_to_setup_object_storage.md) to learn how to setup different object storage.
     bucket: ""
+    # -- Env for mount pod and format, such as `a: b`
+    envs: ""
+    # -- Config for mount pod. Read [this document](https://github.com/juicedata/juicefs-csi-driver/blob/master/docs/en/examples/config-and-env.md) for more usage.
+    configs: ""
+    # -- Config for trash days
+    trashDays: ""
 
 
   mountOptions:
   # -- Mount Options. Read [this document](https://github.com/juicedata/juicefs/blob/main/docs/en/command_reference.md#juicefs-mount) to learn how to set different mount options.
+  # Example:
+  # - debug
+  # - cache-size=2048
+  # - cache-dir=/var/foo
 
   mountPod:
     # mount pod resource requests & limits


### PR DESCRIPTION
JuiceFS CSI Driver has some new releases. Upgrade juicefs chart to newest v0.13.2 in kubesphere.