### PR TITLE
1.The qbd is packaged into the csi-neonsan image, and is no longer mounted from the physical machine to the POD 2. csi-neonsan-controller and csi-neonsan-node use the same image 3. Update the version using the image

### DIFF
--- a/src/test/csi-neonsan/templates/node-ds.yaml
+++ b/src/test/csi-neonsan/templates/node-ds.yaml
@@ -74,8 +74,6 @@ spec:
             mountPath: /csi
           - name: neonsan-config
             mountPath: /etc/neonsan/qbd.conf
-          - name: qbd
-            mountPath: /usr/sbin/qbd
           - name: dev-dir
             mountPath: /dev
           - name: plugin-dir
@@ -125,10 +123,6 @@ spec:
         - name: neonsan-config
           hostPath:
             path: {{ .Values.driver.config }}
-            type: File
-        - name: qbd
-          hostPath:
-            path: /usr/sbin/qbd
             type: File
         - name: plugin-dir
           hostPath:

--- a/src/test/csi-neonsan/values.yaml
+++ b/src/test/csi-neonsan/values.yaml
@@ -15,12 +15,12 @@
 driver:
   name: neonsan.csi.qingstor.com
   repository: csiplugin/csi-neonsan
-  tag: v1.2.1
+  tag: v1.2.2
   pullPolicy: IfNotPresent
   config: /etc/neonsan/qbd.conf
   node:
-    repository: csiplugin/csi-neonsan-ubuntu
-    tag: v1.2.1
+    repository: csiplugin/csi-neonsan
+    tag: v1.2.2
     pullPolicy: IfNotPresent
 
 provisioner:


### PR DESCRIPTION
1.The qbd is packaged into the csi-neonsan image, and is no longer mounted from the physical machine to the POD
2. csi-neonsan-controller and csi-neonsan-node use the same image
3. Update the version using the image
