### PR TITLE
Change radondb mysql & pg name and icon

### DIFF
--- a/src/test/radondb-mysql/Chart.yaml
+++ b/src/test/radondb-mysql/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: radondb-mysql
+name: mysql
 description: High Availability MySQL Cluster, Open Source.
 home: https://github.com/radondb/radondb-mysql-kubernetes.git
 
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -37,6 +37,5 @@ maintainers:
 - email: radondb@yunify.com
   name: RadonDB
 
-icon: https://xenondb.pek3b.qingstor.com/icons/radondb-mysql.svg
 annotations:
   "app.kubesphere.io/category": "Database & Cache"

--- a/src/test/radondb-postgresql/Chart.yaml
+++ b/src/test/radondb-postgresql/Chart.yaml
@@ -5,7 +5,6 @@ dependencies:
   version: 1.4.2
 description: Chart for PostgreSQL with HA architecture.
 home: https://github.com/radondb/radondb-postgresql-kubernetes.git
-icon: https://xenondb.pek3b.qingstor.com/icons/radondb-mysql.svg
 keywords:
 - postgresql
 - repmgr
@@ -20,11 +19,11 @@ maintainers:
 - email: radondb@yunify.com
   name: RadonDB
 
-name: radondb-postgresql
+name: postgresql
 sources:
 - https://github.com/radondb/radondb-postgresql-kubernetes.git
 - https://www.postgresql.org/
-version: 1.0.2
+version: 1.0.3
 annotations:
   "app.kubesphere.io/category": "Database & Cache"
   "app.kubesphere.io/display-name": "RadonDB PostgreSQL"


### PR DESCRIPTION
<img width="1440" alt="截屏2022-11-02 18 15 25" src="https://user-images.githubusercontent.com/5917832/199464026-91d44fde-a12f-46a4-849a-660e2f80c9ba.png">

If radondb is enable in kse

<img width="1133" alt="截屏2022-11-02 16 14 54" src="https://user-images.githubusercontent.com/5917832/199464240-fc0aa502-554d-468e-8ed0-74b85f84d321.png">
<img width="1133" alt="截屏2022-11-02 16 14 33" src="https://user-images.githubusercontent.com/5917832/199464247-f333e4d5-1d4c-4397-98c7-44f04d4a08a4.png">

there are two mysql and pg with radondb name and radondb icon

so，change old radondb mysql & pg name and icon，like this
<img width="1440" alt="截屏2022-11-02 18 15 25" src="https://user-images.githubusercontent.com/5917832/199464471-6fc67803-6146-491e-8f5f-f950d18ee479.png">
