### PR TITLE
Upgrade Chaos Mesh to v2.5.0

### DIFF
--- a/src/stable/chaos-mesh/Chart.yaml
+++ b/src/stable/chaos-mesh/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   artifacthub.io/operatorCapabilities: Seamless Upgrades
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 2.4.1
+appVersion: 2.5.0
 description: Chaos Mesh is a cloud-native Chaos Engineering platform that orchestrates
   chaos on Kubernetes environments.
 home: https://chaos-mesh.org
@@ -30,4 +30,4 @@ maintainers:
 name: chaos-mesh
 sources:
 - https://github.com/pingcap/chaos-mesh
-version: 2.4.1
+version: 2.5.0

--- a/src/stable/chaos-mesh/README.md
+++ b/src/stable/chaos-mesh/README.md
@@ -27,6 +27,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `images.registry` | The global container registry for the images, you could replace it with your self-hosted container registry. | `ghcr.io` |
 | `images.tag` | The global image tag (for example, semiVer with prefix v, or latest). | `latest` |
 | `imagePullSecrets` | Global Docker registry secret names as an array  | [] (does not add image pull secrets to deployed pods) |
+| `controllerManager.securityContext` | Pod securityContext if needed | `{}` |
 | `controllerManager.hostNetwork` | Running chaos-controller-manager on host network | `false` |
 | `controllerManager.allowHostNetworkTesting`   | Allow testing on `hostNetwork` pods | `false` |
 | `controllerManager.serviceAccount` | The serviceAccount for chaos-controller-manager | `chaos-controller-manager` |
@@ -74,6 +75,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `chaosDaemon.updateStrategy` | Specify DaemonSetUpdateStrategy for chaos-daemon | `{}` |
 | `dashboard.create` | Enable chaos-dashboard | `false` |
 | `dashboard.rootUrl` | Specify the base url for openid/oauth2 (like GCP Auth Integration) callback URL. | `http://localhost:2333` |
+| `dashboard.securityContext` | Pod securityContext if needed | `{}` |
 | `dashboard.hostNetwork` | Running chaos-dashboard on host network | `false` |
 | `dashboard.replicaCount` | Replicas of chaos-dashboard | `1` |
 | `dashboard.priorityClassName` | Custom priorityClassName for using pod priorities | `` |

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_awschaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_awschaos.yaml
@@ -68,6 +68,10 @@ spec:
                 description: Endpoint indicates the endpoint of the aws server. Just
                   used it in test now.
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               secretName:
                 description: SecretName defines the name of kubernetes secret.
                 type: string

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_azurechaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_azurechaos.yaml
@@ -62,6 +62,10 @@ spec:
                 description: LUN indicates the Logical Unit Number of the data disk.
                   Needed in disk-detach.
                 type: integer
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               resourceGroupName:
                 description: ResourceGroupName defines the name of ResourceGroup
                 type: string

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_blockchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_blockchaos.yaml
@@ -80,6 +80,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_dnschaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_dnschaos.yaml
@@ -80,6 +80,10 @@ spec:
                 items:
                   type: string
                 type: array
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_gcpchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_gcpchaos.yaml
@@ -65,6 +65,10 @@ spec:
               project:
                 description: Project defines the ID of gcp project.
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               secretName:
                 description: SecretName defines the name of kubernetes secret. It
                   is used for GCP credentials.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_httpchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_httpchaos.yaml
@@ -113,6 +113,10 @@ spec:
                 description: Port represents the target port to be proxy of.
                 format: int32
                 type: integer
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               replace:
                 description: Replace is a rule to replace some contents in target.
                 properties:
@@ -254,6 +258,36 @@ spec:
                 - Request
                 - Response
                 type: string
+              tls:
+                description: TLS is the tls config, will override PodHttpChaos if
+                  there are multiple HTTPChaos experiments are applied
+                properties:
+                  caName:
+                    description: CAName represents the data name of ca file in secret,
+                      `ca.crt` for example
+                    type: string
+                  certName:
+                    description: CertName represents the data name of cert file in
+                      secret, `tls.crt` for example
+                    type: string
+                  keyName:
+                    description: KeyName represents the data name of key file in secret,
+                      `tls.key` for example
+                    type: string
+                  secretName:
+                    description: SecretName represents the name of required secret
+                      resource
+                    type: string
+                  secretNamespace:
+                    description: SecretNamespace represents the namespace of required
+                      secret resource
+                    type: string
+                required:
+                - certName
+                - keyName
+                - secretName
+                - secretNamespace
+                type: object
               value:
                 description: Value is required when the mode is set to `FixedMode`
                   / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`, provide

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_iochaos.yaml
@@ -194,6 +194,10 @@ spec:
                 description: 'Percent defines the percentage of injection errors and
                   provides a number from 0-100. default: 100.'
                 type: integer
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_jvmchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_jvmchaos.yaml
@@ -115,6 +115,10 @@ spec:
                 description: the port of agent server, default 9277
                 format: int32
                 type: integer
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               ruleData:
                 description: the byteman rule's data for action 'ruleData'
                 type: string

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_kernelchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_kernelchaos.yaml
@@ -127,6 +127,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_networkchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_networkchaos.yaml
@@ -182,6 +182,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_physicalmachinechaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_physicalmachinechaos.yaml
@@ -866,6 +866,10 @@ spec:
                     description: The path of `redis-server` command-line tool
                     type: boolean
                 type: object
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select physical machines that are
                   used to inject chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_podchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_podchaos.yaml
@@ -77,6 +77,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_podhttpchaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_podhttpchaos.yaml
@@ -184,6 +184,36 @@ spec:
                   - target
                   type: object
                 type: array
+              tls:
+                description: TLS is the tls config, will be override if there are
+                  multiple HTTPChaos experiments are applied
+                properties:
+                  caName:
+                    description: CAName represents the data name of ca file in secret,
+                      `ca.crt` for example
+                    type: string
+                  certName:
+                    description: CertName represents the data name of cert file in
+                      secret, `tls.crt` for example
+                    type: string
+                  keyName:
+                    description: KeyName represents the data name of key file in secret,
+                      `tls.key` for example
+                    type: string
+                  secretName:
+                    description: SecretName represents the name of required secret
+                      resource
+                    type: string
+                  secretNamespace:
+                    description: SecretNamespace represents the namespace of required
+                      secret resource
+                    type: string
+                required:
+                - certName
+                - keyName
+                - secretName
+                - secretNamespace
+                type: object
             type: object
           status:
             description: PodHttpChaosStatus defines the actual state of PodHttpChaos.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_remoteclusters.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_remoteclusters.yaml
@@ -1,0 +1,106 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: remoteclusters.chaos-mesh.org
+spec:
+  group: chaos-mesh.org
+  names:
+    kind: RemoteCluster
+    listKind: RemoteClusterList
+    plural: remoteclusters
+    singular: remotecluster
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RemoteCluster defines a remote cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RemoteClusterSpec defines the specification of a remote cluster
+            properties:
+              configOverride:
+                description: RawMessage is a raw encoded JSON value. It implements
+                  Marshaler and Unmarshaler and can be used to delay JSON decoding
+                  or precompute a JSON encoding.
+                format: byte
+                type: string
+              kubeConfig:
+                description: RemoteClusterKubeConfig refers to a secret by which we'll
+                  use to connect remote cluster
+                properties:
+                  secretRef:
+                    description: RemoteClusterSecretRef refers to a secret in any
+                      namespaces
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                required:
+                - secretRef
+                type: object
+              namespace:
+                type: string
+            required:
+            - kubeConfig
+            - namespace
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions represents the current condition of the remote
+                  cluster
+                items:
+                  properties:
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentVersion:
+                type: string
+            required:
+            - currentVersion
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_schedules.yaml
@@ -66,6 +66,10 @@ spec:
                     description: Endpoint indicates the endpoint of the aws server.
                       Just used it in test now.
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   secretName:
                     description: SecretName defines the name of kubernetes secret.
                     type: string
@@ -102,6 +106,10 @@ spec:
                     description: LUN indicates the Logical Unit Number of the data
                       disk. Needed in disk-detach.
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   resourceGroupName:
                     description: ResourceGroupName defines the name of ResourceGroup
                     type: string
@@ -160,6 +168,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -314,6 +326,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -444,6 +460,10 @@ spec:
                   project:
                     description: Project defines the ID of gcp project.
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   secretName:
                     description: SecretName defines the name of kubernetes secret.
                       It is used for GCP credentials.
@@ -538,6 +558,10 @@ spec:
                     description: Port represents the target port to be proxy of.
                     format: int32
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   replace:
                     description: Replace is a rule to replace some contents in target.
                     properties:
@@ -682,6 +706,36 @@ spec:
                     - Request
                     - Response
                     type: string
+                  tls:
+                    description: TLS is the tls config, will override PodHttpChaos
+                      if there are multiple HTTPChaos experiments are applied
+                    properties:
+                      caName:
+                        description: CAName represents the data name of ca file in
+                          secret, `ca.crt` for example
+                        type: string
+                      certName:
+                        description: CertName represents the data name of cert file
+                          in secret, `tls.crt` for example
+                        type: string
+                      keyName:
+                        description: KeyName represents the data name of key file
+                          in secret, `tls.key` for example
+                        type: string
+                      secretName:
+                        description: SecretName represents the name of required secret
+                          resource
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace represents the namespace of required
+                          secret resource
+                        type: string
+                    required:
+                    - certName
+                    - keyName
+                    - secretName
+                    - secretNamespace
+                    type: object
                   value:
                     description: Value is required when the mode is set to `FixedMode`
                       / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`,
@@ -850,6 +904,10 @@ spec:
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -1034,6 +1092,10 @@ spec:
                     description: the port of agent server, default 9277
                     format: int32
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   ruleData:
                     description: the byteman rule's data for action 'ruleData'
                     type: string
@@ -1241,6 +1303,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -1488,6 +1554,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -2551,6 +2621,10 @@ spec:
                         description: The path of `redis-server` command-line tool
                         type: boolean
                     type: object
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select physical machines that
                       are used to inject chaos action.
@@ -2727,6 +2801,10 @@ spec:
                     - fixed-percent
                     - random-max-percent
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -2860,6 +2938,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -3065,6 +3147,10 @@ spec:
                     - fixed-percent
                     - random-max-percent
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -3223,6 +3309,10 @@ spec:
                               description: Endpoint indicates the endpoint of the
                                 aws server. Just used it in test now.
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             secretName:
                               description: SecretName defines the name of kubernetes
                                 secret.
@@ -3261,6 +3351,10 @@ spec:
                               description: LUN indicates the Logical Unit Number of
                                 the data disk. Needed in disk-detach.
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             resourceGroupName:
                               description: ResourceGroupName defines the name of ResourceGroup
                               type: string
@@ -3324,6 +3418,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -3514,6 +3612,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -3654,6 +3756,10 @@ spec:
                             project:
                               description: Project defines the ID of gcp project.
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             secretName:
                               description: SecretName defines the name of kubernetes
                                 secret. It is used for GCP credentials.
@@ -3752,6 +3858,10 @@ spec:
                                 of.
                               format: int32
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             replace:
                               description: Replace is a rule to replace some contents
                                 in target.
@@ -3907,6 +4017,36 @@ spec:
                               - Request
                               - Response
                               type: string
+                            tls:
+                              description: TLS is the tls config, will override PodHttpChaos
+                                if there are multiple HTTPChaos experiments are applied
+                              properties:
+                                caName:
+                                  description: CAName represents the data name of
+                                    ca file in secret, `ca.crt` for example
+                                  type: string
+                                certName:
+                                  description: CertName represents the data name of
+                                    cert file in secret, `tls.crt` for example
+                                  type: string
+                                keyName:
+                                  description: KeyName represents the data name of
+                                    key file in secret, `tls.key` for example
+                                  type: string
+                                secretName:
+                                  description: SecretName represents the name of required
+                                    secret resource
+                                  type: string
+                                secretNamespace:
+                                  description: SecretNamespace represents the namespace
+                                    of required secret resource
+                                  type: string
+                              required:
+                              - certName
+                              - keyName
+                              - secretName
+                              - secretNamespace
+                              type: object
                             value:
                               description: Value is required when the mode is set
                                 to `FixedMode` / `FixedPercentMode` / `RandomMaxPercentMode`.
@@ -4083,6 +4223,10 @@ spec:
                                 errors and provides a number from 0-100. default:
                                 100.'
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -4280,6 +4424,10 @@ spec:
                               description: the port of agent server, default 9277
                               format: int32
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             ruleData:
                               description: the byteman rule's data for action 'ruleData'
                               type: string
@@ -4505,6 +4653,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -4773,6 +4925,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -5904,6 +6060,10 @@ spec:
                                     tool
                                   type: boolean
                               type: object
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select physical machines
                                 that are used to inject chaos action.
@@ -6090,6 +6250,10 @@ spec:
                               - fixed-percent
                               - random-max-percent
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -6238,6 +6402,10 @@ spec:
                                   description: Endpoint indicates the endpoint of
                                     the aws server. Just used it in test now.
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 secretName:
                                   description: SecretName defines the name of kubernetes
                                     secret.
@@ -6276,6 +6444,10 @@ spec:
                                   description: LUN indicates the Logical Unit Number
                                     of the data disk. Needed in disk-detach.
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 resourceGroupName:
                                   description: ResourceGroupName defines the name
                                     of ResourceGroup
@@ -6341,6 +6513,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -6513,6 +6689,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -6657,6 +6837,10 @@ spec:
                                 project:
                                   description: Project defines the ID of gcp project.
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 secretName:
                                   description: SecretName defines the name of kubernetes
                                     secret. It is used for GCP credentials.
@@ -6759,6 +6943,10 @@ spec:
                                     be proxy of.
                                   format: int32
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 replace:
                                   description: Replace is a rule to replace some contents
                                     in target.
@@ -6918,6 +7106,37 @@ spec:
                                   - Request
                                   - Response
                                   type: string
+                                tls:
+                                  description: TLS is the tls config, will override
+                                    PodHttpChaos if there are multiple HTTPChaos experiments
+                                    are applied
+                                  properties:
+                                    caName:
+                                      description: CAName represents the data name
+                                        of ca file in secret, `ca.crt` for example
+                                      type: string
+                                    certName:
+                                      description: CertName represents the data name
+                                        of cert file in secret, `tls.crt` for example
+                                      type: string
+                                    keyName:
+                                      description: KeyName represents the data name
+                                        of key file in secret, `tls.key` for example
+                                      type: string
+                                    secretName:
+                                      description: SecretName represents the name
+                                        of required secret resource
+                                      type: string
+                                    secretNamespace:
+                                      description: SecretNamespace represents the
+                                        namespace of required secret resource
+                                      type: string
+                                  required:
+                                  - certName
+                                  - keyName
+                                  - secretName
+                                  - secretNamespace
+                                  type: object
                                 value:
                                   description: Value is required when the mode is
                                     set to `FixedMode` / `FixedPercentMode` / `RandomMaxPercentMode`.
@@ -7096,6 +7315,10 @@ spec:
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -7299,6 +7522,10 @@ spec:
                                   description: the port of agent server, default 9277
                                   format: int32
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 ruleData:
                                   description: the byteman rule's data for action
                                     'ruleData'
@@ -7533,6 +7760,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -7806,6 +8037,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -8974,6 +9209,10 @@ spec:
                                         tool
                                       type: boolean
                                   type: object
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select physical
                                     machines that are used to inject chaos action.
@@ -9169,6 +9408,10 @@ spec:
                                   - fixed-percent
                                   - random-max-percent
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -9316,6 +9559,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -9543,6 +9790,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -9801,6 +10052,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -13124,6 +13379,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_stresschaos.yaml
@@ -59,6 +59,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_timechaos.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_timechaos.yaml
@@ -67,6 +67,10 @@ spec:
                 - fixed-percent
                 - random-max-percent
                 type: string
+              remoteCluster:
+                description: RemoteCluster represents the remote cluster where the
+                  chaos will be deployed
+                type: string
               selector:
                 description: Selector is used to select pods that are used to inject
                   chaos action.

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_workflownodes.yaml
@@ -72,6 +72,10 @@ spec:
                     description: Endpoint indicates the endpoint of the aws server.
                       Just used it in test now.
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   secretName:
                     description: SecretName defines the name of kubernetes secret.
                     type: string
@@ -108,6 +112,10 @@ spec:
                     description: LUN indicates the Logical Unit Number of the data
                       disk. Needed in disk-detach.
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   resourceGroupName:
                     description: ResourceGroupName defines the name of ResourceGroup
                     type: string
@@ -166,6 +174,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -338,6 +350,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -468,6 +484,10 @@ spec:
                   project:
                     description: Project defines the ID of gcp project.
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   secretName:
                     description: SecretName defines the name of kubernetes secret.
                       It is used for GCP credentials.
@@ -559,6 +579,10 @@ spec:
                     description: Port represents the target port to be proxy of.
                     format: int32
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   replace:
                     description: Replace is a rule to replace some contents in target.
                     properties:
@@ -703,6 +727,36 @@ spec:
                     - Request
                     - Response
                     type: string
+                  tls:
+                    description: TLS is the tls config, will override PodHttpChaos
+                      if there are multiple HTTPChaos experiments are applied
+                    properties:
+                      caName:
+                        description: CAName represents the data name of ca file in
+                          secret, `ca.crt` for example
+                        type: string
+                      certName:
+                        description: CertName represents the data name of cert file
+                          in secret, `tls.crt` for example
+                        type: string
+                      keyName:
+                        description: KeyName represents the data name of key file
+                          in secret, `tls.key` for example
+                        type: string
+                      secretName:
+                        description: SecretName represents the name of required secret
+                          resource
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace represents the namespace of required
+                          secret resource
+                        type: string
+                    required:
+                    - certName
+                    - keyName
+                    - secretName
+                    - secretNamespace
+                    type: object
                   value:
                     description: Value is required when the mode is set to `FixedMode`
                       / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`,
@@ -871,6 +925,10 @@ spec:
                     description: 'Percent defines the percentage of injection errors
                       and provides a number from 0-100. default: 100.'
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -1055,6 +1113,10 @@ spec:
                     description: the port of agent server, default 9277
                     format: int32
                     type: integer
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   ruleData:
                     description: the byteman rule's data for action 'ruleData'
                     type: string
@@ -1262,6 +1324,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -1509,6 +1575,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -2572,6 +2642,10 @@ spec:
                         description: The path of `redis-server` command-line tool
                         type: boolean
                     type: object
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select physical machines that
                       are used to inject chaos action.
@@ -2748,6 +2822,10 @@ spec:
                     - fixed-percent
                     - random-max-percent
                     type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
+                    type: string
                   selector:
                     description: Selector is used to select pods that are used to
                       inject chaos action.
@@ -2886,6 +2964,10 @@ spec:
                         description: Endpoint indicates the endpoint of the aws server.
                           Just used it in test now.
                         type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       secretName:
                         description: SecretName defines the name of kubernetes secret.
                         type: string
@@ -2923,6 +3005,10 @@ spec:
                         description: LUN indicates the Logical Unit Number of the
                           data disk. Needed in disk-detach.
                         type: integer
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       resourceGroupName:
                         description: ResourceGroupName defines the name of ResourceGroup
                         type: string
@@ -2983,6 +3069,10 @@ spec:
                         - fixed
                         - fixed-percent
                         - random-max-percent
+                        type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
                         type: string
                       selector:
                         description: Selector is used to select pods that are used
@@ -3142,6 +3232,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       selector:
                         description: Selector is used to select pods that are used
                           to inject chaos action.
@@ -3277,6 +3371,10 @@ spec:
                       project:
                         description: Project defines the ID of gcp project.
                         type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       secretName:
                         description: SecretName defines the name of kubernetes secret.
                           It is used for GCP credentials.
@@ -3373,6 +3471,10 @@ spec:
                         description: Port represents the target port to be proxy of.
                         format: int32
                         type: integer
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       replace:
                         description: Replace is a rule to replace some contents in
                           target.
@@ -3522,6 +3624,36 @@ spec:
                         - Request
                         - Response
                         type: string
+                      tls:
+                        description: TLS is the tls config, will override PodHttpChaos
+                          if there are multiple HTTPChaos experiments are applied
+                        properties:
+                          caName:
+                            description: CAName represents the data name of ca file
+                              in secret, `ca.crt` for example
+                            type: string
+                          certName:
+                            description: CertName represents the data name of cert
+                              file in secret, `tls.crt` for example
+                            type: string
+                          keyName:
+                            description: KeyName represents the data name of key file
+                              in secret, `tls.key` for example
+                            type: string
+                          secretName:
+                            description: SecretName represents the name of required
+                              secret resource
+                            type: string
+                          secretNamespace:
+                            description: SecretNamespace represents the namespace
+                              of required secret resource
+                            type: string
+                        required:
+                        - certName
+                        - keyName
+                        - secretName
+                        - secretNamespace
+                        type: object
                       value:
                         description: Value is required when the mode is set to `FixedMode`
                           / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`,
@@ -3693,6 +3825,10 @@ spec:
                         description: 'Percent defines the percentage of injection
                           errors and provides a number from 0-100. default: 100.'
                         type: integer
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       selector:
                         description: Selector is used to select pods that are used
                           to inject chaos action.
@@ -3882,6 +4018,10 @@ spec:
                         description: the port of agent server, default 9277
                         format: int32
                         type: integer
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       ruleData:
                         description: the byteman rule's data for action 'ruleData'
                         type: string
@@ -4096,6 +4236,10 @@ spec:
                         - fixed
                         - fixed-percent
                         - random-max-percent
+                        type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
                         type: string
                       selector:
                         description: Selector is used to select pods that are used
@@ -4349,6 +4493,10 @@ spec:
                         - fixed
                         - fixed-percent
                         - random-max-percent
+                        type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
                         type: string
                       selector:
                         description: Selector is used to select pods that are used
@@ -5428,6 +5576,10 @@ spec:
                             description: The path of `redis-server` command-line tool
                             type: boolean
                         type: object
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       selector:
                         description: Selector is used to select physical machines
                           that are used to inject chaos action.
@@ -5607,6 +5759,10 @@ spec:
                         - fixed-percent
                         - random-max-percent
                         type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       selector:
                         description: Selector is used to select pods that are used
                           to inject chaos action.
@@ -5744,6 +5900,10 @@ spec:
                         - fixed
                         - fixed-percent
                         - random-max-percent
+                        type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
                         type: string
                       selector:
                         description: Selector is used to select pods that are used
@@ -5953,6 +6113,10 @@ spec:
                         - fixed-percent
                         - random-max-percent
                         type: string
+                      remoteCluster:
+                        description: RemoteCluster represents the remote cluster where
+                          the chaos will be deployed
+                        type: string
                       selector:
                         description: Selector is used to select pods that are used
                           to inject chaos action.
@@ -6113,6 +6277,10 @@ spec:
                                   description: Endpoint indicates the endpoint of
                                     the aws server. Just used it in test now.
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 secretName:
                                   description: SecretName defines the name of kubernetes
                                     secret.
@@ -6151,6 +6319,10 @@ spec:
                                   description: LUN indicates the Logical Unit Number
                                     of the data disk. Needed in disk-detach.
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 resourceGroupName:
                                   description: ResourceGroupName defines the name
                                     of ResourceGroup
@@ -6216,6 +6388,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -6413,6 +6589,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -6557,6 +6737,10 @@ spec:
                                 project:
                                   description: Project defines the ID of gcp project.
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 secretName:
                                   description: SecretName defines the name of kubernetes
                                     secret. It is used for GCP credentials.
@@ -6656,6 +6840,10 @@ spec:
                                     be proxy of.
                                   format: int32
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 replace:
                                   description: Replace is a rule to replace some contents
                                     in target.
@@ -6815,6 +7003,37 @@ spec:
                                   - Request
                                   - Response
                                   type: string
+                                tls:
+                                  description: TLS is the tls config, will override
+                                    PodHttpChaos if there are multiple HTTPChaos experiments
+                                    are applied
+                                  properties:
+                                    caName:
+                                      description: CAName represents the data name
+                                        of ca file in secret, `ca.crt` for example
+                                      type: string
+                                    certName:
+                                      description: CertName represents the data name
+                                        of cert file in secret, `tls.crt` for example
+                                      type: string
+                                    keyName:
+                                      description: KeyName represents the data name
+                                        of key file in secret, `tls.key` for example
+                                      type: string
+                                    secretName:
+                                      description: SecretName represents the name
+                                        of required secret resource
+                                      type: string
+                                    secretNamespace:
+                                      description: SecretNamespace represents the
+                                        namespace of required secret resource
+                                      type: string
+                                  required:
+                                  - certName
+                                  - keyName
+                                  - secretName
+                                  - secretNamespace
+                                  type: object
                                 value:
                                   description: Value is required when the mode is
                                     set to `FixedMode` / `FixedPercentMode` / `RandomMaxPercentMode`.
@@ -6993,6 +7212,10 @@ spec:
                                     injection errors and provides a number from 0-100.
                                     default: 100.'
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -7196,6 +7419,10 @@ spec:
                                   description: the port of agent server, default 9277
                                   format: int32
                                   type: integer
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 ruleData:
                                   description: the byteman rule's data for action
                                     'ruleData'
@@ -7430,6 +7657,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -7705,6 +7936,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -8873,6 +9108,10 @@ spec:
                                         tool
                                       type: boolean
                                   type: object
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select physical
                                     machines that are used to inject chaos action.
@@ -9068,6 +9307,10 @@ spec:
                                   - fixed-percent
                                   - random-max-percent
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -9222,6 +9465,10 @@ spec:
                                       description: Endpoint indicates the endpoint
                                         of the aws server. Just used it in test now.
                                       type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     secretName:
                                       description: SecretName defines the name of
                                         kubernetes secret.
@@ -9260,6 +9507,10 @@ spec:
                                       description: LUN indicates the Logical Unit
                                         Number of the data disk. Needed in disk-detach.
                                       type: integer
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     resourceGroupName:
                                       description: ResourceGroupName defines the name
                                         of ResourceGroup
@@ -9325,6 +9576,10 @@ spec:
                                       - fixed
                                       - fixed-percent
                                       - random-max-percent
+                                      type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
                                       type: string
                                     selector:
                                       description: Selector is used to select pods
@@ -9502,6 +9757,10 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     selector:
                                       description: Selector is used to select pods
                                         that are used to inject chaos action.
@@ -9652,6 +9911,10 @@ spec:
                                     project:
                                       description: Project defines the ID of gcp project.
                                       type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     secretName:
                                       description: SecretName defines the name of
                                         kubernetes secret. It is used for GCP credentials.
@@ -9757,6 +10020,10 @@ spec:
                                         to be proxy of.
                                       format: int32
                                       type: integer
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     replace:
                                       description: Replace is a rule to replace some
                                         contents in target.
@@ -9923,6 +10190,40 @@ spec:
                                       - Request
                                       - Response
                                       type: string
+                                    tls:
+                                      description: TLS is the tls config, will override
+                                        PodHttpChaos if there are multiple HTTPChaos
+                                        experiments are applied
+                                      properties:
+                                        caName:
+                                          description: CAName represents the data
+                                            name of ca file in secret, `ca.crt` for
+                                            example
+                                          type: string
+                                        certName:
+                                          description: CertName represents the data
+                                            name of cert file in secret, `tls.crt`
+                                            for example
+                                          type: string
+                                        keyName:
+                                          description: KeyName represents the data
+                                            name of key file in secret, `tls.key`
+                                            for example
+                                          type: string
+                                        secretName:
+                                          description: SecretName represents the name
+                                            of required secret resource
+                                          type: string
+                                        secretNamespace:
+                                          description: SecretNamespace represents
+                                            the namespace of required secret resource
+                                          type: string
+                                      required:
+                                      - certName
+                                      - keyName
+                                      - secretName
+                                      - secretNamespace
+                                      type: object
                                     value:
                                       description: Value is required when the mode
                                         is set to `FixedMode` / `FixedPercentMode`
@@ -10105,6 +10406,10 @@ spec:
                                         of injection errors and provides a number
                                         from 0-100. default: 100.'
                                       type: integer
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     selector:
                                       description: Selector is used to select pods
                                         that are used to inject chaos action.
@@ -10315,6 +10620,10 @@ spec:
                                         9277
                                       format: int32
                                       type: integer
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     ruleData:
                                       description: the byteman rule's data for action
                                         'ruleData'
@@ -10559,6 +10868,10 @@ spec:
                                       - fixed
                                       - fixed-percent
                                       - random-max-percent
+                                      type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
                                       type: string
                                     selector:
                                       description: Selector is used to select pods
@@ -10840,6 +11153,10 @@ spec:
                                       - fixed
                                       - fixed-percent
                                       - random-max-percent
+                                      type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
                                       type: string
                                     selector:
                                       description: Selector is used to select pods
@@ -12042,6 +12359,10 @@ spec:
                                             command-line tool
                                           type: boolean
                                       type: object
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     selector:
                                       description: Selector is used to select physical
                                         machines that are used to inject chaos action.
@@ -12244,6 +12565,10 @@ spec:
                                       - fixed-percent
                                       - random-max-percent
                                       type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
+                                      type: string
                                     selector:
                                       description: Selector is used to select pods
                                         that are used to inject chaos action.
@@ -12396,6 +12721,10 @@ spec:
                                       - fixed
                                       - fixed-percent
                                       - random-max-percent
+                                      type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
                                       type: string
                                     selector:
                                       description: Selector is used to select pods
@@ -12630,6 +12959,10 @@ spec:
                                       - fixed
                                       - fixed-percent
                                       - random-max-percent
+                                      type: string
+                                    remoteCluster:
+                                      description: RemoteCluster represents the remote
+                                        cluster where the chaos will be deployed
                                       type: string
                                     selector:
                                       description: Selector is used to select pods
@@ -12898,6 +13231,10 @@ spec:
                                   - fixed
                                   - fixed-percent
                                   - random-max-percent
+                                  type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
                                   type: string
                                 selector:
                                   description: Selector is used to select pods that
@@ -16416,6 +16753,10 @@ spec:
                                   - fixed-percent
                                   - random-max-percent
                                   type: string
+                                remoteCluster:
+                                  description: RemoteCluster represents the remote
+                                    cluster where the chaos will be deployed
+                                  type: string
                                 selector:
                                   description: Selector is used to select pods that
                                     are used to inject chaos action.
@@ -16675,6 +17016,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to
@@ -19669,6 +20014,10 @@ spec:
                     - fixed
                     - fixed-percent
                     - random-max-percent
+                    type: string
+                  remoteCluster:
+                    description: RemoteCluster represents the remote cluster where
+                      the chaos will be deployed
                     type: string
                   selector:
                     description: Selector is used to select pods that are used to

--- a/src/stable/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
+++ b/src/stable/chaos-mesh/crds/chaos-mesh.org_workflows.yaml
@@ -78,6 +78,10 @@ spec:
                           description: Endpoint indicates the endpoint of the aws
                             server. Just used it in test now.
                           type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         secretName:
                           description: SecretName defines the name of kubernetes secret.
                           type: string
@@ -115,6 +119,10 @@ spec:
                           description: LUN indicates the Logical Unit Number of the
                             data disk. Needed in disk-detach.
                           type: integer
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         resourceGroupName:
                           description: ResourceGroupName defines the name of ResourceGroup
                           type: string
@@ -176,6 +184,10 @@ spec:
                           - fixed
                           - fixed-percent
                           - random-max-percent
+                          type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
                           type: string
                         selector:
                           description: Selector is used to select pods that are used
@@ -358,6 +370,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         selector:
                           description: Selector is used to select pods that are used
                             to inject chaos action.
@@ -494,6 +510,10 @@ spec:
                         project:
                           description: Project defines the ID of gcp project.
                           type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         secretName:
                           description: SecretName defines the name of kubernetes secret.
                             It is used for GCP credentials.
@@ -589,6 +609,10 @@ spec:
                             of.
                           format: int32
                           type: integer
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         replace:
                           description: Replace is a rule to replace some contents
                             in target.
@@ -739,6 +763,36 @@ spec:
                           - Request
                           - Response
                           type: string
+                        tls:
+                          description: TLS is the tls config, will override PodHttpChaos
+                            if there are multiple HTTPChaos experiments are applied
+                          properties:
+                            caName:
+                              description: CAName represents the data name of ca file
+                                in secret, `ca.crt` for example
+                              type: string
+                            certName:
+                              description: CertName represents the data name of cert
+                                file in secret, `tls.crt` for example
+                              type: string
+                            keyName:
+                              description: KeyName represents the data name of key
+                                file in secret, `tls.key` for example
+                              type: string
+                            secretName:
+                              description: SecretName represents the name of required
+                                secret resource
+                              type: string
+                            secretNamespace:
+                              description: SecretNamespace represents the namespace
+                                of required secret resource
+                              type: string
+                          required:
+                          - certName
+                          - keyName
+                          - secretName
+                          - secretNamespace
+                          type: object
                         value:
                           description: Value is required when the mode is set to `FixedMode`
                             / `FixedPercentMode` / `RandomMaxPercentMode`. If `FixedMode`,
@@ -910,6 +964,10 @@ spec:
                           description: 'Percent defines the percentage of injection
                             errors and provides a number from 0-100. default: 100.'
                           type: integer
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         selector:
                           description: Selector is used to select pods that are used
                             to inject chaos action.
@@ -1100,6 +1158,10 @@ spec:
                           description: the port of agent server, default 9277
                           format: int32
                           type: integer
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         ruleData:
                           description: the byteman rule's data for action 'ruleData'
                           type: string
@@ -1316,6 +1378,10 @@ spec:
                           - fixed
                           - fixed-percent
                           - random-max-percent
+                          type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
                           type: string
                         selector:
                           description: Selector is used to select pods that are used
@@ -1574,6 +1640,10 @@ spec:
                           - fixed
                           - fixed-percent
                           - random-max-percent
+                          type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
                           type: string
                         selector:
                           description: Selector is used to select pods that are used
@@ -2679,6 +2749,10 @@ spec:
                                 tool
                               type: boolean
                           type: object
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         selector:
                           description: Selector is used to select physical machines
                             that are used to inject chaos action.
@@ -2860,6 +2934,10 @@ spec:
                           - fixed-percent
                           - random-max-percent
                           type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
+                          type: string
                         selector:
                           description: Selector is used to select pods that are used
                             to inject chaos action.
@@ -3004,6 +3082,10 @@ spec:
                               description: Endpoint indicates the endpoint of the
                                 aws server. Just used it in test now.
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             secretName:
                               description: SecretName defines the name of kubernetes
                                 secret.
@@ -3042,6 +3124,10 @@ spec:
                               description: LUN indicates the Logical Unit Number of
                                 the data disk. Needed in disk-detach.
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             resourceGroupName:
                               description: ResourceGroupName defines the name of ResourceGroup
                               type: string
@@ -3105,6 +3191,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -3271,6 +3361,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -3411,6 +3505,10 @@ spec:
                             project:
                               description: Project defines the ID of gcp project.
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             secretName:
                               description: SecretName defines the name of kubernetes
                                 secret. It is used for GCP credentials.
@@ -3512,6 +3610,10 @@ spec:
                                 of.
                               format: int32
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             replace:
                               description: Replace is a rule to replace some contents
                                 in target.
@@ -3667,6 +3769,36 @@ spec:
                               - Request
                               - Response
                               type: string
+                            tls:
+                              description: TLS is the tls config, will override PodHttpChaos
+                                if there are multiple HTTPChaos experiments are applied
+                              properties:
+                                caName:
+                                  description: CAName represents the data name of
+                                    ca file in secret, `ca.crt` for example
+                                  type: string
+                                certName:
+                                  description: CertName represents the data name of
+                                    cert file in secret, `tls.crt` for example
+                                  type: string
+                                keyName:
+                                  description: KeyName represents the data name of
+                                    key file in secret, `tls.key` for example
+                                  type: string
+                                secretName:
+                                  description: SecretName represents the name of required
+                                    secret resource
+                                  type: string
+                                secretNamespace:
+                                  description: SecretNamespace represents the namespace
+                                    of required secret resource
+                                  type: string
+                              required:
+                              - certName
+                              - keyName
+                              - secretName
+                              - secretNamespace
+                              type: object
                             value:
                               description: Value is required when the mode is set
                                 to `FixedMode` / `FixedPercentMode` / `RandomMaxPercentMode`.
@@ -3843,6 +3975,10 @@ spec:
                                 errors and provides a number from 0-100. default:
                                 100.'
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -4040,6 +4176,10 @@ spec:
                               description: the port of agent server, default 9277
                               format: int32
                               type: integer
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             ruleData:
                               description: the byteman rule's data for action 'ruleData'
                               type: string
@@ -4265,6 +4405,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -4531,6 +4675,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -5662,6 +5810,10 @@ spec:
                                     tool
                                   type: boolean
                               type: object
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select physical machines
                                 that are used to inject chaos action.
@@ -5848,6 +6000,10 @@ spec:
                               - fixed-percent
                               - random-max-percent
                               type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
+                              type: string
                             selector:
                               description: Selector is used to select pods that are
                                 used to inject chaos action.
@@ -5991,6 +6147,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -6211,6 +6371,10 @@ spec:
                               - fixed
                               - fixed-percent
                               - random-max-percent
+                              type: string
+                            remoteCluster:
+                              description: RemoteCluster represents the remote cluster
+                                where the chaos will be deployed
                               type: string
                             selector:
                               description: Selector is used to select pods that are
@@ -6463,6 +6627,10 @@ spec:
                           - fixed
                           - fixed-percent
                           - random-max-percent
+                          type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
                           type: string
                         selector:
                           description: Selector is used to select pods that are used
@@ -9642,6 +9810,10 @@ spec:
                           - fixed
                           - fixed-percent
                           - random-max-percent
+                          type: string
+                        remoteCluster:
+                          description: RemoteCluster represents the remote cluster
+                            where the chaos will be deployed
                           type: string
                         selector:
                           description: Selector is used to select pods that are used

--- a/src/stable/chaos-mesh/templates/chaos-dashboard-deployment.yaml
+++ b/src/stable/chaos-mesh/templates/chaos-dashboard-deployment.yaml
@@ -38,6 +38,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.dashboard.securityContext | indent 12 }}
       {{- if .Values.dashboard.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/src/stable/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/src/stable/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -39,6 +39,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.controllerManager.securityContext | indent 12 }}
       {{- if .Values.controllerManager.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/src/stable/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/src/stable/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -98,7 +98,7 @@ metadata:
     app.kubernetes.io/component: controller-manager
 rules:
   - apiGroups: [ "" ]
-    resources: [ "services", "endpoints" ]
+    resources: [ "services", "endpoints", "secrets" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "authorization.k8s.io" ]
     resources:
@@ -110,9 +110,9 @@ rules:
   - apiGroups: [ "coordination.k8s.io" ]
     resources: [ "leases" ]
     verbs: [ "*" ]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["*"]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "*" ]
 ---
 # bindings cluster level
 kind: ClusterRoleBinding

--- a/src/stable/chaos-mesh/values.yaml
+++ b/src/stable/chaos-mesh/values.yaml
@@ -48,7 +48,7 @@ images:
   # images.registry is the global container registry for the images, you could replace it with your self-hosted container registry.
   registry: "ghcr.io"
   # images.tag is the global image tag (for example, semiVer with prefix v, or latest).
-  tag: "v2.4.1"
+  tag: "v2.5.0"
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -56,6 +56,8 @@ imagePullSecrets: []
 # - name: secretName
 
 controllerManager:
+  # securityContext if needed
+  securityContext: {}
   # running chaos-controller-manager on host network
   hostNetwork: false
   # Allow testing on `hostNetwork` pods. This is Dangerous. Please run only as temporary solution.
@@ -232,6 +234,8 @@ dashboard:
   create: true
   # rootUrl specify the base url for openid/oauth2 (like GCP Auth Integration) callback URL.
   rootUrl: http://localhost:2333
+  # securityContext if needed
+  securityContext: {}
   # running chaos-dashboard on host network
   hostNetwork: false
   # replicas of chaos-dashboard
@@ -504,6 +508,7 @@ webhook:
     - physicalmachinechaos
     - physicalmachine
     - statuscheck
+    - remotecluster
 
 bpfki:
   # Enable chaos-kernel


### PR DESCRIPTION
This PR upgrades Chaos Mesh to v2.5.0. Copy from https://github.com/chaos-mesh/charts/blob/gh-pages/chaos-mesh-2.5.0.tgz.