### PR TITLE
upgrade helm version to 3.14.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ helm() {
   "${currentDir}/helm" $@
 }
 
-helmVersion=3.6.3
+helmVersion=3.14.0
 prepareHelm() {
   local helmUrl=https://get.helm.sh/helm-v$helmVersion-linux-amd64.tar.gz
   echo "Downloading Helm Client from '$helmUrl' ..."


### PR DESCRIPTION
fix unexpected lint error:

```
==> Linting ks-core
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: template: ks-core/templates/kubesphere-config.yaml:13:17: executing "ks-core/templates/kubesphere-config.yaml" at <include "portal.host" .>: error calling include: template: ks-core/templates/_helpers.tpl:62:39: executing "portal.host" at <.Values.portal.https.port>: nil pointer evaluating interface {}.port
```